### PR TITLE
Feature/add empty option for find command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 | `status` | `status` | Show tracked and staged state overview. |
 | `tracklist` | `tracklist [--output <text|json>] [--field <id|path>]...` | List tracked targets with tracked file IDs. |
 | `version` | `version` | Print application version and build target. |
-| `find` | `find [--tag <tag>] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...` | Search commits by optional tag and local-time range filters. |
+| `find` | `find [--tag <tag>] [--empty|--no-empty] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...` | Search commits by optional tag, empty-commit, and local-time range filters. |
 | `show` | `show [--output <text|json>] [--field <commit_id|message|created_at|paths|tags>]... <commitId>` | Show one commit details payload. |
 | `journal` | `journal` | Show recent journal logs in reverse chronological order. |
 | `tag ls` | `tag ls <commitId>` | List tags for one commit. |
@@ -165,12 +165,14 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 
 ### find
 
-- Usage: `omohi find [--tag <tag>] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...`
-- Summary: Search commits by optional tag and local-time range filters.
+- Usage: `omohi find [--tag <tag>] [--empty|--no-empty] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...`
+- Summary: Search commits by optional tag, empty-commit, and local-time range filters.
 - Positionals:
   - None
 - Options:
   - `-t`, `--tag` `<tag>` (optional): Filter commits by tag name.
+  - `--empty` (optional): Return only empty commits.
+  - `--no-empty` (optional): Return only non-empty commits.
   - `-s`, `--since` `<YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>` (optional): Filter commits created at or after the given local date/time.
   - `-u`, `--until` `<YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>` (optional): Filter commits created at or before the given local date/time.
   - `--limit` `<1-500>` (optional): Limit the number of returned commits. Accepts integers from 1 through 500.
@@ -180,14 +182,17 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
   - `omohi find`
   - `omohi find --limit 100`
   - `omohi find --tag release`
+  - `omohi find --empty`
+  - `omohi find --no-empty --tag release`
   - `omohi find --since 2026-03-17`
   - `omohi find --tag release --since 2026-03-17 --until 2026-03-17T23:59:59`
   - `omohi find --field commit_id --field created_at`
   - `omohi find --output json --tag release`
 - Notes:
-  - When tag and time filters are set, intersection is returned.
+  - When tag, empty-commit, and time filters are set, intersection is returned.
   - Date-only and datetime values are interpreted in the local timezone.
   - `--since` and `--until` are inclusive bounds.
+  - `--empty` and `--no-empty` cannot be combined.
   - Without `--limit`, `find` returns up to 500 commits and pages text output on TTY with `less` when available.
   - `--limit` accepts integers from 1 through 500 and disables pager output when set.
   - Each result is shown as commit ID, local timestamp, and commit message in a multi-line block.

--- a/docs/man/omohi.1
+++ b/docs/man/omohi.1
@@ -295,17 +295,25 @@ omohi version
 .SS find
 .TP
 .B Summary
-Search commits by optional tag and local\-time range filters.
+Search commits by optional tag, empty\-commit, and local\-time range filters.
 .TP
 .B Usage
 .nf
-omohi find [\-\-tag <tag>] [\-\-since <YYYY\-MM\-DD|YYYY\-MM\-DDTHH:MM:SS>] [\-\-until <YYYY\-MM\-DD|YYYY\-MM\-DDTHH:MM:SS>] [\-\-limit <1\-500>] [\-\-output <text|json>] [\-\-field <commit_id|message|created_at>]...
+omohi find [\-\-tag <tag>] [\-\-empty|\-\-no\-empty] [\-\-since <YYYY\-MM\-DD|YYYY\-MM\-DDTHH:MM:SS>] [\-\-until <YYYY\-MM\-DD|YYYY\-MM\-DDTHH:MM:SS>] [\-\-limit <1\-500>] [\-\-output <text|json>] [\-\-field <commit_id|message|created_at>]...
 .fi
 .TP
 .B Options
 .RS 4
 .B \-t, \-\-tag <tag>
 optional: Filter commits by tag name.
+.RE
+.RS 4
+.B \-\-empty
+optional: Return only empty commits.
+.RE
+.RS 4
+.B \-\-no\-empty
+optional: Return only non\-empty commits.
 .RE
 .RS 4
 .B \-s, \-\-since <YYYY\-MM\-DD|YYYY\-MM\-DDTHH:MM:SS>
@@ -333,6 +341,8 @@ optional, repeatable: Select one or more result fields. Repeat to keep field ord
 omohi find
 omohi find \-\-limit 100
 omohi find \-\-tag release
+omohi find \-\-empty
+omohi find \-\-no\-empty \-\-tag release
 omohi find \-\-since 2026\-03\-17
 omohi find \-\-tag release \-\-since 2026\-03\-17 \-\-until 2026\-03\-17T23:59:59
 omohi find \-\-field commit_id \-\-field created_at
@@ -341,13 +351,16 @@ omohi find \-\-output json \-\-tag release
 .TP
 .B Notes
 .RS 4
-When tag and time filters are set, intersection is returned.
+When tag, empty\-commit, and time filters are set, intersection is returned.
 .RE
 .RS 4
 Date\-only and datetime values are interpreted in the local timezone.
 .RE
 .RS 4
 `\-\-since` and `\-\-until` are inclusive bounds.
+.RE
+.RS 4
+`\-\-empty` and `\-\-no\-empty` cannot be combined.
 .RE
 .RS 4
 Without `\-\-limit`, `find` returns up to 500 commits and pages text output on TTY with `less` when available.

--- a/src/app/cli/command/find.zig
+++ b/src/app/cli/command/find.zig
@@ -14,7 +14,15 @@ pub fn run(allocator: std.mem.Allocator, args: parser_types.FindArgs) !command_t
     defer omohi.deinit(allocator);
 
     const limit = args.limit orelse default_limit;
-    var list = try find_ops.find(allocator, omohi.dir, args.tag, args.since_millis, args.until_millis, limit);
+    var list = try find_ops.find(
+        allocator,
+        omohi.dir,
+        args.tag,
+        toOpsEmptyFilter(args.empty_filter),
+        args.since_millis,
+        args.until_millis,
+        limit,
+    );
     defer find_ops.freeCommitSummaryList(allocator, &list);
 
     const output = try presenter.findResult(allocator, &list, args);
@@ -23,6 +31,15 @@ pub fn run(allocator: std.mem.Allocator, args: parser_types.FindArgs) !command_t
         .to_stderr = false,
         .exit_code = exit_code.ok,
         .page_output = shouldPageOutput(args),
+    };
+}
+
+// Converts the parser-level empty-commit filter into the ops/store representation.
+fn toOpsEmptyFilter(filter: parser_types.FindEmptyFilter) find_ops.FindEmptyFilter {
+    return switch (filter) {
+        .all => .all,
+        .empty_only => .empty_only,
+        .non_empty_only => .non_empty_only,
     };
 }
 
@@ -38,6 +55,7 @@ test "find uses 500 item default limit" {
 test "find enables paging only for default text output" {
     try std.testing.expect(shouldPageOutput(.{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,
@@ -49,6 +67,7 @@ test "find enables paging only for default text output" {
 
     try std.testing.expect(!shouldPageOutput(.{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,
@@ -60,6 +79,7 @@ test "find enables paging only for default text output" {
 
     try std.testing.expect(!shouldPageOutput(.{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,

--- a/src/app/cli/command_catalog.zig
+++ b/src/app/cli/command_catalog.zig
@@ -182,11 +182,13 @@ pub const all = [_]CommandSpec{
     },
     .{
         .name = "find",
-        .usage = "find [--tag <tag>] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...",
-        .summary = "Search commits by optional tag and local-time range filters.",
+        .usage = "find [--tag <tag>] [--empty|--no-empty] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...",
+        .summary = "Search commits by optional tag, empty-commit, and local-time range filters.",
         .positionals = &.{},
         .options = &.{
             .{ .long = "tag", .short = 't', .value_name = "tag", .required = false, .repeatable = false, .description = "Filter commits by tag name." },
+            .{ .long = "empty", .short = null, .value_name = null, .required = false, .repeatable = false, .description = "Return only empty commits." },
+            .{ .long = "no-empty", .short = null, .value_name = null, .required = false, .repeatable = false, .description = "Return only non-empty commits." },
             .{ .long = "since", .short = 's', .value_name = "YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS", .required = false, .repeatable = false, .description = "Filter commits created at or after the given local date/time." },
             .{ .long = "until", .short = 'u', .value_name = "YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS", .required = false, .repeatable = false, .description = "Filter commits created at or before the given local date/time." },
             .{ .long = "limit", .short = null, .value_name = "1-500", .required = false, .repeatable = false, .description = "Limit the number of returned commits. Accepts integers from 1 through 500." },
@@ -197,15 +199,18 @@ pub const all = [_]CommandSpec{
             "omohi find",
             "omohi find --limit 100",
             "omohi find --tag release",
+            "omohi find --empty",
+            "omohi find --no-empty --tag release",
             "omohi find --since 2026-03-17",
             "omohi find --tag release --since 2026-03-17 --until 2026-03-17T23:59:59",
             "omohi find --field commit_id --field created_at",
             "omohi find --output json --tag release",
         },
         .notes = &.{
-            "When tag and time filters are set, intersection is returned.",
+            "When tag, empty-commit, and time filters are set, intersection is returned.",
             "Date-only and datetime values are interpreted in the local timezone.",
             "`--since` and `--until` are inclusive bounds.",
+            "`--empty` and `--no-empty` cannot be combined.",
             "Without `--limit`, `find` returns up to 500 commits and pages text output on TTY with `less` when available.",
             "`--limit` accepts integers from 1 through 500 and disables pager output when set.",
             "Each result is shown as commit ID, local timestamp, and commit message in a multi-line block.",
@@ -462,6 +467,8 @@ fn optionTakesValue(comptime command_name: []const u8, comptime option_long: []c
     if (std.mem.eql(u8, command_name, "tracklist") and std.mem.eql(u8, option_long, "output")) return true;
     if (std.mem.eql(u8, command_name, "tracklist") and std.mem.eql(u8, option_long, "field")) return true;
     if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "tag")) return true;
+    if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "empty")) return false;
+    if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "no-empty")) return false;
     if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "since")) return true;
     if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "until")) return true;
     if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "limit")) return true;

--- a/src/app/cli/parser/parse.zig
+++ b/src/app/cli/parser/parse.zig
@@ -348,6 +348,7 @@ fn parseCommit(allocator: std.mem.Allocator, args: []const []const u8) !types.Pa
 // Parses `find` options and validates any provided local-time range filters.
 fn parseFind(allocator: std.mem.Allocator, args: []const []const u8) !types.ParsedRequest {
     var tag_name: ?[]const u8 = null;
+    var empty_filter: types.FindEmptyFilter = .all;
     var since: ?[]const u8 = null;
     var until: ?[]const u8 = null;
     var since_millis: ?i64 = null;
@@ -371,6 +372,20 @@ fn parseFind(allocator: std.mem.Allocator, args: []const []const u8) !types.Pars
             if (scan.parseLongOption(token)) |opt| {
                 if (scan.equalsIgnoreAsciiCase(opt.key, "tag")) {
                     tag_name = try scan.optionValue(args, &idx, opt.value);
+                    continue;
+                }
+
+                if (scan.equalsIgnoreAsciiCase(opt.key, "empty")) {
+                    if (opt.value != null) return error.UnknownOption;
+                    if (empty_filter == .non_empty_only) return error.InvalidArgument;
+                    empty_filter = .empty_only;
+                    continue;
+                }
+
+                if (scan.equalsIgnoreAsciiCase(opt.key, "no-empty")) {
+                    if (opt.value != null) return error.UnknownOption;
+                    if (empty_filter == .empty_only) return error.InvalidArgument;
+                    empty_filter = .non_empty_only;
                     continue;
                 }
 
@@ -439,6 +454,7 @@ fn parseFind(allocator: std.mem.Allocator, args: []const []const u8) !types.Pars
 
     return .{ .find = .{
         .tag = tag_name,
+        .empty_filter = empty_filter,
         .since = since,
         .until = until,
         .since_millis = since_millis,
@@ -929,6 +945,7 @@ test "parser normalizes option keys for find" {
         switch (parsed) {
             .find => |args| {
                 try std.testing.expectEqualStrings("release", args.tag.?);
+                try std.testing.expectEqual(types.FindEmptyFilter.all, args.empty_filter);
                 try std.testing.expectEqualStrings("2026-03-12", args.since.?);
                 try std.testing.expectEqualStrings("2026-03-13", args.until.?);
             },
@@ -943,6 +960,7 @@ test "parser normalizes option keys for find" {
         switch (parsed) {
             .find => |args| {
                 try std.testing.expectEqualStrings("release", args.tag.?);
+                try std.testing.expectEqual(types.FindEmptyFilter.all, args.empty_filter);
                 try std.testing.expectEqualStrings("2026-03-12", args.since.?);
                 try std.testing.expectEqualStrings("2026-03-13T12:00:00", args.until.?);
             },
@@ -988,6 +1006,7 @@ test "parser accepts find output and repeated fields" {
     switch (parsed) {
         .find => |args| {
             try std.testing.expectEqual(types.OutputFormat.json, args.output);
+            try std.testing.expectEqual(types.FindEmptyFilter.all, args.empty_filter);
             try std.testing.expectEqual(@as(usize, 2), args.fields.len);
             try std.testing.expectEqual(types.FindField.commit_id, args.fields[0]);
             try std.testing.expectEqual(types.FindField.created_at, args.fields[1]);
@@ -1005,7 +1024,10 @@ test "parser accepts find limit values" {
         defer types.deinitParsedRequest(allocator, &parsed);
 
         switch (parsed) {
-            .find => |args| try std.testing.expectEqual(@as(?usize, 25), args.limit),
+            .find => |args| {
+                try std.testing.expectEqual(types.FindEmptyFilter.all, args.empty_filter);
+                try std.testing.expectEqual(@as(?usize, 25), args.limit);
+            },
             else => return error.UnexpectedResult,
         }
     }
@@ -1016,7 +1038,34 @@ test "parser accepts find limit values" {
         defer types.deinitParsedRequest(allocator, &parsed);
 
         switch (parsed) {
-            .find => |args| try std.testing.expectEqual(@as(?usize, 500), args.limit),
+            .find => |args| {
+                try std.testing.expectEqual(types.FindEmptyFilter.all, args.empty_filter);
+                try std.testing.expectEqual(@as(?usize, 500), args.limit);
+            },
+            else => return error.UnexpectedResult,
+        }
+    }
+}
+
+test "parser accepts find empty filters" {
+    const allocator = std.testing.allocator;
+
+    {
+        var parsed = try parseArgs(allocator, &.{ "find", "--empty" });
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .find => |args| try std.testing.expectEqual(types.FindEmptyFilter.empty_only, args.empty_filter),
+            else => return error.UnexpectedResult,
+        }
+    }
+
+    {
+        var parsed = try parseArgs(allocator, &.{ "find", "--no-empty" });
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .find => |args| try std.testing.expectEqual(types.FindEmptyFilter.non_empty_only, args.empty_filter),
             else => return error.UnexpectedResult,
         }
     }
@@ -1028,6 +1077,18 @@ test "parser rejects invalid find limit values" {
     try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "find", "--limit", "0" }));
     try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "find", "--limit", "501" }));
     try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "find", "--limit", "abc" }));
+}
+
+test "parser rejects conflicting find empty filters" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "find", "--empty", "--no-empty" }));
+    try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "find", "--no-empty", "--empty" }));
+}
+
+test "parser rejects find empty filters with values" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.UnknownOption, parseArgs(allocator, &.{ "find", "--empty=true" }));
+    try std.testing.expectError(error.UnknownOption, parseArgs(allocator, &.{ "find", "--no-empty=false" }));
 }
 
 test "parser accepts show options before commit id" {

--- a/src/app/cli/parser/types.zig
+++ b/src/app/cli/parser/types.zig
@@ -14,6 +14,12 @@ pub const FindField = enum {
     created_at,
 };
 
+pub const FindEmptyFilter = enum {
+    all,
+    empty_only,
+    non_empty_only,
+};
+
 pub const ShowField = enum {
     commit_id,
     message,
@@ -54,6 +60,7 @@ pub const TracklistArgs = struct {
 
 pub const FindArgs = struct {
     tag: ?[]const u8,
+    empty_filter: FindEmptyFilter,
     since: ?[]const u8,
     until: ?[]const u8,
     since_millis: ?i64,

--- a/src/app/cli/presenter/output.zig
+++ b/src/app/cli/presenter/output.zig
@@ -1145,6 +1145,7 @@ test "findResult renders heading and commit blocks" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = "release",
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,
@@ -1177,6 +1178,7 @@ test "findResult renders selected fields as text rows" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,
@@ -1199,6 +1201,7 @@ test "findResult renders no commits message" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,
@@ -1225,6 +1228,7 @@ test "findResult renders since heading" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = null,
+        .empty_filter = .all,
         .since = "2026-03-10",
         .until = null,
         .since_millis = 0,
@@ -1251,6 +1255,7 @@ test "findResult renders tag and range heading" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = "release",
+        .empty_filter = .all,
         .since = "2026-03-10",
         .until = "2026-03-11",
         .since_millis = 0,
@@ -1277,6 +1282,7 @@ test "findResult renders json output" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,
@@ -1306,6 +1312,7 @@ test "findResult renders selected fields as json" {
 
     const output = try findResult(std.testing.allocator, &list, .{
         .tag = null,
+        .empty_filter = .all,
         .since = null,
         .until = null,
         .since_millis = null,

--- a/src/ops/find_ops.zig
+++ b/src/ops/find_ops.zig
@@ -4,18 +4,20 @@ const store_api = @import("../store/api.zig");
 
 pub const CommitSummary = store_api.CommitSummary;
 pub const CommitSummaryList = store_api.CommitSummaryList;
+pub const FindEmptyFilter = store_api.FindEmptyFilter;
 
-/// Finds commits by optional tag and local-time range filters.
+/// Finds commits by optional tag, empty-commit, and local-time range filters.
 pub fn find(
     allocator: std.mem.Allocator,
     omohi_dir: std.fs.Dir,
     tag_name: ?[]const u8,
+    empty_filter: FindEmptyFilter,
     since_millis: ?i64,
     until_millis: ?i64,
     limit: usize,
 ) !CommitSummaryList {
     try store_api.ensureStoreVersion(allocator, omohi_dir);
-    return store_api.find(allocator, omohi_dir, tag_name, since_millis, until_millis, limit);
+    return store_api.find(allocator, omohi_dir, tag_name, empty_filter, since_millis, until_millis, limit);
 }
 
 // Releases the owned commit summary strings returned by `find`.

--- a/src/store/api.zig
+++ b/src/store/api.zig
@@ -55,6 +55,11 @@ pub const CommitSummaryList = api_types.CommitSummaryList;
 pub const StringList = api_types.StringList;
 pub const TagList = api_types.TagList;
 pub const CommitDetails = api_types.CommitDetails;
+pub const FindEmptyFilter = enum {
+    all,
+    empty_only,
+    non_empty_only,
+};
 pub const TrackedEntry = local_tracked.TrackedEntry;
 pub const TrackedList = local_tracked.TrackedList;
 pub const StagedEntry = local_staged.StagedEntry;
@@ -526,11 +531,12 @@ pub fn freeRmBatchOutcome(allocator: std.mem.Allocator, outcome: *RmBatchOutcome
     freeStringList(allocator, &outcome.unstaged_paths);
 }
 
-/// Finds commits with optional tag and epoch-millis range filters.
+/// Finds commits with optional tag, empty-commit, and epoch-millis range filters.
 pub fn find(
     allocator: std.mem.Allocator,
     omohi_dir: std.fs.Dir,
     tag_name: ?[]const u8,
+    empty_filter: FindEmptyFilter,
     since_millis: ?i64,
     until_millis: ?i64,
     limit: usize,
@@ -574,6 +580,11 @@ pub fn find(
             }
         }
 
+        if (!matchesFindEmptyFilter(parsed.is_empty, empty_filter)) {
+            freeParsedCommit(allocator, &parsed);
+            continue;
+        }
+
         try matches.append(.{
             .parsed = parsed,
             .created_at_millis = created_at_millis,
@@ -598,6 +609,15 @@ pub fn find(
     }
 
     return out;
+}
+
+// Reports whether the commit's empty flag matches the requested `find` filter.
+fn matchesFindEmptyFilter(is_empty: bool, filter: FindEmptyFilter) bool {
+    return switch (filter) {
+        .all => true,
+        .empty_only => is_empty,
+        .non_empty_only => !is_empty,
+    };
 }
 
 // Releases owned strings held by commit summaries returned from `find`.
@@ -1870,7 +1890,7 @@ test "nextUniqueCommitIdentity advances createdAt when commit id already exists"
     const snapshot_id = filledHexId('a');
     const original_created_at = "2026-04-12T00:00:00.000Z";
     const existing_commit_id = hash.commitIdFrom(snapshot_id[0..], "memo", original_created_at);
-    try writeFindFixtureCommit(allocator, omohi_dir, existing_commit_id[0..], "memo", original_created_at);
+    try writeFindFixtureCommit(allocator, omohi_dir, existing_commit_id[0..], "memo", original_created_at, false);
 
     const start_millis = try local_date.parseUtcIso8601Millis(original_created_at);
     const identity = try nextUniqueCommitIdentityFromMillis(allocator, persistence, snapshot_id[0..], "memo", start_millis);
@@ -1977,6 +1997,7 @@ fn writeFindFixtureCommit(
     commit_id: []const u8,
     message: []const u8,
     created_at: []const u8,
+    is_empty: bool,
 ) !void {
     const persistence = PersistenceLayout.init(omohi_dir);
     const path = try persistence.commitsPath(allocator, commit_id);
@@ -1985,8 +2006,8 @@ fn writeFindFixtureCommit(
     const snapshot_id = filledHexId('a');
     const content = try std.fmt.allocPrint(
         allocator,
-        "snapshotId={s}\nmessage={s}\ncreatedAt={s}\nempty=false\n",
-        .{ snapshot_id[0..], message, created_at },
+        "snapshotId={s}\nmessage={s}\ncreatedAt={s}\nempty={s}\n",
+        .{ snapshot_id[0..], message, created_at, if (is_empty) "true" else "false" },
     );
     defer allocator.free(content);
 
@@ -2808,10 +2829,10 @@ test "find sorts by createdAt desc and applies the requested limit" {
         const message = try std.fmt.allocPrint(allocator, "msg-{d}", .{idx + 1});
         defer allocator.free(message);
 
-        try writeFindFixtureCommit(allocator, omohi_dir, commit_id[0..], message, created_at);
+        try writeFindFixtureCommit(allocator, omohi_dir, commit_id[0..], message, created_at, false);
     }
 
-    var list = try find(allocator, omohi_dir, null, null, null, 10);
+    var list = try find(allocator, omohi_dir, null, .all, null, null, 10);
     defer freeCommitSummaryList(allocator, &list);
 
     try std.testing.expectEqual(@as(usize, 10), list.items.len);
@@ -2832,32 +2853,32 @@ test "find applies tag and time range filters as intersection" {
     const commit_a = filledHexId('a');
     const commit_b = filledHexId('b');
 
-    try writeFindFixtureCommit(allocator, omohi_dir, commit_a[0..], "release-a", "2026-03-10T18:00:00.000Z");
-    try writeFindFixtureCommit(allocator, omohi_dir, commit_b[0..], "prod-b", "2026-03-07T01:00:00.000Z");
+    try writeFindFixtureCommit(allocator, omohi_dir, commit_a[0..], "release-a", "2026-03-10T18:00:00.000Z", false);
+    try writeFindFixtureCommit(allocator, omohi_dir, commit_b[0..], "prod-b", "2026-03-07T01:00:00.000Z", false);
 
     const release_tags = [_][]const u8{"release"};
     const prod_tags = [_][]const u8{"prod"};
     try writeFindFixtureTags(allocator, omohi_dir, commit_a[0..], &release_tags);
     try writeFindFixtureTags(allocator, omohi_dir, commit_b[0..], &prod_tags);
 
-    var by_tag = try find(allocator, omohi_dir, "release", null, null, 10);
+    var by_tag = try find(allocator, omohi_dir, "release", .all, null, null, 10);
     defer freeCommitSummaryList(allocator, &by_tag);
     try std.testing.expectEqual(@as(usize, 1), by_tag.items.len);
     try std.testing.expectEqualStrings("release-a", by_tag.items[0].message);
 
     const created_a = try local_date.parseUtcIso8601Millis("2026-03-10T18:00:00.000Z");
-    var by_range = try find(allocator, omohi_dir, null, created_a, created_a, 10);
+    var by_range = try find(allocator, omohi_dir, null, .all, created_a, created_a, 10);
     defer freeCommitSummaryList(allocator, &by_range);
     try std.testing.expectEqual(@as(usize, 1), by_range.items.len);
     try std.testing.expectEqualStrings("release-a", by_range.items[0].message);
     try std.testing.expectEqual(@as(usize, 29), by_range.items[0].local_created_at.len);
 
-    var by_tag_and_range = try find(allocator, omohi_dir, "release", created_a, created_a, 10);
+    var by_tag_and_range = try find(allocator, omohi_dir, "release", .all, created_a, created_a, 10);
     defer freeCommitSummaryList(allocator, &by_tag_and_range);
     try std.testing.expectEqual(@as(usize, 1), by_tag_and_range.items.len);
     try std.testing.expectEqualStrings("release-a", by_tag_and_range.items[0].message);
 
-    var no_intersection = try find(allocator, omohi_dir, "prod", created_a, created_a, 10);
+    var no_intersection = try find(allocator, omohi_dir, "prod", .all, created_a, created_a, 10);
     defer freeCommitSummaryList(allocator, &no_intersection);
     try std.testing.expectEqual(@as(usize, 0), no_intersection.items.len);
 }
@@ -2890,13 +2911,68 @@ test "find returns local createdAt in user timezone" {
     defer omohi_dir.close();
 
     const commit_id = filledHexId('a');
-    try writeFindFixtureCommit(allocator, omohi_dir, commit_id[0..], "tokyo", "2026-03-10T18:00:00.123Z");
+    try writeFindFixtureCommit(allocator, omohi_dir, commit_id[0..], "tokyo", "2026-03-10T18:00:00.123Z", false);
 
-    var list = try find(allocator, omohi_dir, null, null, null, 10);
+    var list = try find(allocator, omohi_dir, null, .all, null, null, 10);
     defer freeCommitSummaryList(allocator, &list);
 
     try std.testing.expectEqual(@as(usize, 1), list.items.len);
     try std.testing.expectEqualStrings("2026-03-11T03:00:00.123+09:00", list.items[0].local_created_at);
+}
+
+test "find filters empty and non-empty commits" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+
+    const empty_commit = filledHexId('a');
+    const normal_commit = filledHexId('b');
+
+    try writeFindFixtureCommit(allocator, omohi_dir, empty_commit[0..], "empty", "2026-03-11T00:00:00.000Z", true);
+    try writeFindFixtureCommit(allocator, omohi_dir, normal_commit[0..], "normal", "2026-03-10T00:00:00.000Z", false);
+
+    var empty_only = try find(allocator, omohi_dir, null, .empty_only, null, null, 10);
+    defer freeCommitSummaryList(allocator, &empty_only);
+    try std.testing.expectEqual(@as(usize, 1), empty_only.items.len);
+    try std.testing.expectEqualStrings("empty", empty_only.items[0].message);
+
+    var non_empty_only = try find(allocator, omohi_dir, null, .non_empty_only, null, null, 10);
+    defer freeCommitSummaryList(allocator, &non_empty_only);
+    try std.testing.expectEqual(@as(usize, 1), non_empty_only.items.len);
+    try std.testing.expectEqualStrings("normal", non_empty_only.items[0].message);
+}
+
+test "find applies empty filter together with tag and time range" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+
+    const empty_release = filledHexId('a');
+    const non_empty_release = filledHexId('b');
+    const empty_prod = filledHexId('c');
+
+    try writeFindFixtureCommit(allocator, omohi_dir, empty_release[0..], "empty-release", "2026-03-10T18:00:00.000Z", true);
+    try writeFindFixtureCommit(allocator, omohi_dir, non_empty_release[0..], "non-empty-release", "2026-03-10T18:00:00.000Z", false);
+    try writeFindFixtureCommit(allocator, omohi_dir, empty_prod[0..], "empty-prod", "2026-03-07T01:00:00.000Z", true);
+
+    const release_tags = [_][]const u8{"release"};
+    const prod_tags = [_][]const u8{"prod"};
+    try writeFindFixtureTags(allocator, omohi_dir, empty_release[0..], &release_tags);
+    try writeFindFixtureTags(allocator, omohi_dir, non_empty_release[0..], &release_tags);
+    try writeFindFixtureTags(allocator, omohi_dir, empty_prod[0..], &prod_tags);
+
+    const created_release = try local_date.parseUtcIso8601Millis("2026-03-10T18:00:00.000Z");
+    var list = try find(allocator, omohi_dir, "release", .empty_only, created_release, created_release, 10);
+    defer freeCommitSummaryList(allocator, &list);
+
+    try std.testing.expectEqual(@as(usize, 1), list.items.len);
+    try std.testing.expectEqualStrings("empty-release", list.items[0].message);
 }
 
 test "tagList returns CommitNotFound when commit does not exist" {
@@ -2975,6 +3051,7 @@ test "tagList returns empty when commit exists and has no tags" {
         existing_commit[0..],
         "fixture-message",
         "2026-03-12T00:00:00.000Z",
+        false,
     );
 
     var tags = try tagList(allocator, omohi_dir, existing_commit[0..]);


### PR DESCRIPTION
## Summary

Added `--empty` `--no-empty` options to the `find` command.

## Related Issue

## Testing

- [x] Tests run
- [ ] Not run

List the tests or checks you ran.
If you did not run them, explain why.

## Docs

- [x] Docs updated
- [ ] N/A

List updated docs if applicable.

## Checklist

- [x] The change is small and focused.
- [x] I completed the Testing section.
- [x] I completed the Docs section.
- [x] I called out any breaking change in this PR description.
