### PR TITLE
Fix/bash completion of find command option

### DIFF
--- a/.github/scripts/omohi_completion.sh
+++ b/.github/scripts/omohi_completion.sh
@@ -59,10 +59,13 @@ case "$*" in
     printf '%s\n' --all
     ;;
   "omohi find " )
-    printf '%s\n' -t --tag -d --date
+    printf '%s\n' -t --tag --empty --no-empty -s --since -u --until --limit --output --field
     ;;
-  "omohi find --d" )
-    printf '%s\n' --date
+  "omohi find --e" )
+    printf '%s\n' --empty
+    ;;
+  "omohi find --n" )
+    printf '%s\n' --no-empty
     ;;
   "omohi tracklist " )
     printf '%s\n' --output --field
@@ -123,8 +126,9 @@ assert_reply "-m --message -t --tag --dry-run" omohi commit ""
 assert_reply "--message" omohi commit --m
 assert_reply "-a --all" omohi add -
 assert_reply "--all" omohi add --
-assert_reply "-t --tag -d --date" omohi find ""
-assert_reply "--date" omohi find --d
+assert_reply "-t --tag --empty --no-empty -s --since -u --until --limit --output --field" omohi find ""
+assert_reply "--empty" omohi find --e
+assert_reply "--no-empty" omohi find --n
 assert_reply "--output --field" omohi tracklist ""
 assert_reply "--output" omohi tracklist --o
 assert_reply "text json" omohi tracklist --output ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,9 +133,16 @@ Agents should also refer to directories under `docs/` when they are relevant to 
 - Run `make test-e2e-matrix` when changing CLI options, parser behavior, aliases, output formats, or broad command-pattern coverage.
 - Ensure Bash Completion still works. Use `make test-completion` when commands, subcommands, or options may be affected.
 - If commands, subcommands, or options are added or changed, update completion behavior accordingly.
+- Treat CLI contract changes as multi-surface updates. When commands, subcommands, aliases, or options are added or changed, verify all affected sources together before finishing:
+  - parser behavior and argument structs
+  - command catalog / help text / allowed values
+  - completion sources and completion test fixtures
+  - smoke / matrix / contract tests that cover the changed public behavior
+- Do not mark a CLI change complete after updating only the parser or only the docs. Completion and CLI-facing tests must be checked in the same change when they are in scope.
 - Avoid introducing significant performance regressions. When behavior may affect command cost or traversal size, verify that performance is not materially worse.
 - If commands, subcommands, or options are added or changed, update the generating Zig sources first and then regenerate the user-facing CLI docs:
   - `docs/cli.md`
   - `docs/man/omohi.1`
+- If completion is driven by a hand-maintained source or test fixture rather than generated docs, update that source directly and keep it in sync with the command catalog.
 - Ensure formatting is applied. Use `make fmt-check` at minimum.
 - Prefer `make check` when the change scope is broad enough to affect multiple quality gates.

--- a/docs/codex-common-rules.md
+++ b/docs/codex-common-rules.md
@@ -45,6 +45,16 @@ The intended workflow is "a normal request message + a reference to this documen
 * Confirm that the "design intent" matches the actual file placement and dependencies.
 * If a rule violation is pointed out, re-check related areas across the codebase to avoid missing similar issues.
 
+### 3.8 CLI Contract Changes Must Update All Surfaces
+* Do not treat a CLI change as complete after updating only parser code, only command execution, or only docs.
+* When commands, subcommands, aliases, options, or option values change, verify and update every affected public surface in the same change:
+  * parser behavior and argument structs
+  * command catalog / help text / allowed values
+  * shell completion sources and completion test fixtures
+  * CLI-facing tests that cover the changed contract
+* If user-facing CLI docs are generated, update the generating Zig source first and then regenerate the docs.
+* If completion is hand-maintained, update the completion source and its tests explicitly rather than assuming docs regeneration will cover it.
+
 ## 4. SHOULD
 * Split files with high cognitive load by responsibility.
 * For persistence structures, define structs and types before using them.
@@ -58,6 +68,7 @@ The intended workflow is "a normal request message + a reference to this documen
 * Directory placement that does not match responsibility (for example, putting procedures under `store`)
 * Starting implementation without reading the reference materials specified in the request
 * Cross-cutting refactors without tests
+* Declaring a CLI contract change finished while completion or CLI-facing regression tests are knowingly stale
 
 ## 6. Minimal Additions to a Request (Not a Template)
 Add only the following one or two lines to a normal request message.
@@ -73,6 +84,7 @@ Scope: (target path for this request) / Excluded: (paths not to touch in this re
 * Do placement and naming match the intended responsibilities?
 * Is the public boundary of `api.zig` kept thin?
 * Does the plan include adding or updating tests?
+* If the change touches CLI behavior, does the plan explicitly mention command catalog, completion, and CLI-facing tests?
 
 ## 8. Update Policy
 * If the same issue causes repeated follow-up requests two or more times, promote it into either MUST or SHOULD and add it here.

--- a/src/ops/completion_ops.zig
+++ b/src/ops/completion_ops.zig
@@ -13,7 +13,7 @@ const commit_options = [_][]const u8{ "-e", "--empty", "-m", "--message", "-t", 
 const add_options = [_][]const u8{ "-a", "--all" };
 const untrack_options = [_][]const u8{"--missing"};
 const tracklist_options = [_][]const u8{ "--output", "--field" };
-const find_options = [_][]const u8{ "-t", "--tag", "-s", "--since", "-u", "--until", "--limit", "--output", "--field" };
+const find_options = [_][]const u8{ "-t", "--tag", "--empty", "--no-empty", "-s", "--since", "-u", "--until", "--limit", "--output", "--field" };
 const show_options = [_][]const u8{ "--output", "--field" };
 const output_values = [_][]const u8{ "text", "json" };
 const tracklist_field_values = [_][]const u8{ "id", "path" };
@@ -486,6 +486,14 @@ test "complete returns reference output and field candidates" {
     const allocator = std.testing.allocator;
 
     {
+        const words = [_][]const u8{ "omohi", "find", "" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+        try std.testing.expect(containsCandidate(list.items, "--empty"));
+        try std.testing.expect(containsCandidate(list.items, "--no-empty"));
+    }
+
+    {
         const words = [_][]const u8{ "omohi", "tracklist", "--out" };
         var list = try complete(allocator, null, &words, 2);
         defer freeCandidateList(allocator, &list);
@@ -499,6 +507,14 @@ test "complete returns reference output and field candidates" {
         defer freeCandidateList(allocator, &list);
         try std.testing.expectEqual(@as(usize, 1), list.items.len);
         try std.testing.expectEqualStrings("--limit", list.items[0]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "find", "--n" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+        try std.testing.expectEqual(@as(usize, 1), list.items.len);
+        try std.testing.expectEqualStrings("--no-empty", list.items[0]);
     }
 
     {


### PR DESCRIPTION
## Summary

Fixed bash completion bug of `find` command options.

## Related Issue

## Testing

- [x] Tests run
- [ ] Not run

List the tests or checks you ran.
If you did not run them, explain why.

## Docs

- [x] Docs updated
- [ ] N/A

List updated docs if applicable.

## Checklist

- [x] The change is small and focused.
- [x] I completed the Testing section.
- [x] I completed the Docs section.
- [x] I called out any breaking change in this PR description.
