### PR TITLE
Fix failed E2E testing.

### DIFF
--- a/.github/scripts/omohi_test_lib.sh
+++ b/.github/scripts/omohi_test_lib.sh
@@ -129,12 +129,31 @@ run_omohi_capture() {
   RUN_STDERR="$(cat "$RUN_STDERR_FILE")"
 }
 
+# Builds a shell-safe command line for invoking omohi under a pseudo terminal.
+build_omohi_tty_command() {
+  local command
+  command="$(printf 'HOME=%q %q' "$HOME_DIR" "$OMOHI_BIN")"
+
+  while [ "$#" -gt 0 ]; do
+    command="${command} $(printf '%q' "$1")"
+    shift
+  done
+
+  printf '%s\n' "$command"
+}
+
 run_omohi_capture_tty() {
   RUN_STDOUT_FILE="$TEST_TMP_ROOT/stdout.txt"
   RUN_STDERR_FILE="$TEST_TMP_ROOT/stderr.txt"
 
   set +e
-  script -q /dev/null env HOME="$HOME_DIR" "$OMOHI_BIN" "$@" >"$RUN_STDOUT_FILE" 2>"$RUN_STDERR_FILE"
+  if script --version >/dev/null 2>&1; then
+    local command
+    command="$(build_omohi_tty_command "$@")"
+    script -q -e -c "$command" /dev/null >"$RUN_STDOUT_FILE" 2>"$RUN_STDERR_FILE"
+  else
+    script -q /dev/null env HOME="$HOME_DIR" "$OMOHI_BIN" "$@" >"$RUN_STDOUT_FILE" 2>"$RUN_STDERR_FILE"
+  fi
   RUN_CODE=$?
   set -e
 


### PR DESCRIPTION
## Summary

Fixed e2e test helpers to change `script` command options due to running OS type difference.

## Related Issue

## Testing

- [x] Tests run
- [ ] Not run

List the tests or checks you ran.
If you did not run them, explain why.

## Docs

- [ ] Docs updated
- [x] N/A

List updated docs if applicable.

## Checklist

- [x] The change is small and focused.
- [x] I completed the Testing section.
- [x] I completed the Docs section.
- [x] I called out any breaking change in this PR description.
