### PR TITLE
Add `rm` command `--all` / `-a` option

### DIFF
--- a/.github/scripts/omohi_completion.sh
+++ b/.github/scripts/omohi_completion.sh
@@ -58,6 +58,15 @@ case "$*" in
   "omohi add --" )
     printf '%s\n' --all
     ;;
+  "omohi rm " )
+    printf '%s\n' -a --all
+    ;;
+  "omohi rm -" )
+    printf '%s\n' -a --all
+    ;;
+  "omohi rm --" )
+    printf '%s\n' --all
+    ;;
   "omohi find " )
     printf '%s\n' -t --tag --empty --no-empty -s --since -u --until --limit --output --field
     ;;
@@ -126,6 +135,8 @@ assert_reply "-m --message -t --tag --dry-run" omohi commit ""
 assert_reply "--message" omohi commit --m
 assert_reply "-a --all" omohi add -
 assert_reply "--all" omohi add --
+assert_reply "-a --all" omohi rm -
+assert_reply "--all" omohi rm --
 assert_reply "-t --tag --empty --no-empty -s --since -u --until --limit --output --field" omohi find ""
 assert_reply "--empty" omohi find --e
 assert_reply "--no-empty" omohi find --n

--- a/.github/scripts/omohi_e2e_matrix.sh
+++ b/.github/scripts/omohi_e2e_matrix.sh
@@ -464,6 +464,62 @@ case_030_rm_mixed_with_non_staged() {
   assert_contains "$RUN_STDERR" "Staged file not found: $FILE_B" "rm should report the non-staged file"
 }
 
+case_030_rm_all_short_option() {
+  setup_two_tracked_files
+  run_omohi_capture add "$FILE_A" "$FILE_B"
+  assert_eq "0" "$RUN_CODE" "add should succeed"
+
+  run_omohi_capture rm -a
+  assert_eq "0" "$RUN_CODE" "rm -a should succeed"
+  assert_contains "$RUN_STDOUT" "Unstaged 2 file(s)." "rm -a should report all unstaged files"
+  assert_path_listed "$RUN_STDOUT" "$FILE_A"
+  assert_path_listed "$RUN_STDOUT" "$FILE_B"
+}
+
+case_030_rm_all_long_option_with_deleted_source() {
+  local file
+  file="$(make_note_file "note.txt" $'first version\n')"
+  run_omohi_capture track "$file"
+  assert_eq "0" "$RUN_CODE" "track should succeed"
+  run_omohi_capture add "$file"
+  assert_eq "0" "$RUN_CODE" "add should succeed"
+  rm -f "$file"
+
+  run_omohi_capture rm --all
+  assert_eq "0" "$RUN_CODE" "rm --all should succeed for deleted staged source"
+  assert_contains "$RUN_STDOUT" "Unstaged 1 file(s)." "rm --all should report one unstaged file"
+  assert_path_listed "$RUN_STDOUT" "$file"
+}
+
+case_030_rm_all_mixed_with_path() {
+  local file
+  file="$(make_note_file "note.txt" $'first version\n')"
+  run_omohi_capture track "$file"
+  assert_eq "0" "$RUN_CODE" "track should succeed"
+
+  run_omohi_capture rm -a "$file"
+  assert_eq "2" "$RUN_CODE" "rm -a with explicit path should fail"
+  assert_contains "$RUN_STDERR" "Unexpected argument." "rm -a with path should report usage error"
+}
+
+case_030_rm_all_with_value() {
+  run_omohi_capture rm --all=value
+  assert_eq "2" "$RUN_CODE" "rm --all=value should fail"
+  assert_contains "$RUN_STDERR" "Unknown option." "rm --all=value should report unknown option"
+}
+
+case_030_rm_double_dash_positional() {
+  local tracked
+  tracked="$(make_note_file "tracked.txt" $'tracked\n')"
+  run_omohi_capture track "$tracked"
+  assert_eq "0" "$RUN_CODE" "track should initialize store"
+
+  run_omohi_capture rm -- --all
+  assert_eq "4" "$RUN_CODE" "rm should treat --all as positional path after --"
+  assert_contains "$RUN_STDERR" "Tracked file not found:" "rm should treat --all as path"
+  assert_contains "$RUN_STDERR" "/--all" "rm should resolve the positional path"
+}
+
 case_031_commit_short_message_option() {
   local file
   file="$(make_note_file "note.txt" $'first version\n')"
@@ -1192,6 +1248,11 @@ run_case "rm directory recursive" case_027_rm_directory_recursive
 run_case "rm tracked but not staged" case_028_rm_tracked_but_not_staged
 run_case "rm untracked path" case_029_rm_untracked_path
 run_case "rm mixed staged and non-staged" case_030_rm_mixed_with_non_staged
+run_case "rm all short option" case_030_rm_all_short_option
+run_case "rm all long option with deleted source" case_030_rm_all_long_option_with_deleted_source
+run_case "rm all mixed with path" case_030_rm_all_mixed_with_path
+run_case "rm all with value" case_030_rm_all_with_value
+run_case "rm positional after double dash" case_030_rm_double_dash_positional
 run_case "commit short message option" case_031_commit_short_message_option
 run_case "commit long message option" case_032_commit_long_message_option
 run_case "commit with multiple tags" case_033_commit_with_multiple_tags

--- a/completions/omohi.bash
+++ b/completions/omohi.bash
@@ -59,7 +59,15 @@ _omohi_complete() {
     status|version|journal)
       return 0
       ;;
-    help|untrack|rm|show)
+    rm)
+      if [[ -z "${cur}" || "${cur}" == -* ]]; then
+        _omohi_collect_candidates
+        return 0
+      fi
+      _omohi_collect_candidates
+      return 0
+      ;;
+    help|untrack|show)
       _omohi_collect_candidates
       return 0
       ;;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 | `track` | `track <path>...` | Register one file or recursively track files under a directory. |
 | `untrack` | `untrack (<trackedFileId> | --missing)` | Remove one tracked target by ID or clear all missing tracked targets. |
 | `add` | `add [-a|--all] [<path>...]` | Stage one tracked file, a tracked directory subtree, or all changed tracked files. |
-| `rm` | `rm <path>...` | Remove one staged file or recursively unstage staged files under a directory. |
+| `rm` | `rm [-a|--all] [<path>...]` | Remove one staged file, recursively unstage staged files under a directory, or unstage all staged files. |
 | `commit` | `commit -m <message> [-t <tag>] [--dry-run] [--empty]` | Create a commit from staged entries. |
 | `status` | `status` | Show tracked and staged state overview. |
 | `tracklist` | `tracklist [--output <text|json>] [--field <id|path>]...` | List tracked targets with tracked file IDs. |
@@ -80,18 +80,21 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 
 ### rm
 
-- Usage: `omohi rm <path>...`
-- Summary: Remove one staged file or recursively unstage staged files under a directory.
+- Usage: `omohi rm [-a|--all] [<path>...]`
+- Summary: Remove one staged file, recursively unstage staged files under a directory, or unstage all staged files.
 - Positionals:
-  - `path` (required, repeatable): Path to the staged file or directory to unstage.
+  - `path` (optional, repeatable): Path to the staged file or directory to unstage.
 - Options:
-  - None
+  - `-a`, `--all` (optional): Unstage all currently staged files.
 - Examples:
   - `omohi rm /tmp/note.txt`
   - `omohi rm .`
   - `omohi rm ./*.md`
+  - `omohi rm -a`
 - Notes:
   - When a directory is given, staged files under it are unstaged recursively.
+  - `-a` and `--all` unstage every currently staged file.
+  - `-a` and explicit paths cannot be combined.
   - Untracked, non-staged, and non-regular entries are skipped.
   - Shell-expanded multiple paths are accepted and processed in order.
 

--- a/docs/man/omohi.1
+++ b/docs/man/omohi.1
@@ -132,17 +132,23 @@ Shell\-expanded multiple paths are accepted and processed in order.
 .SS rm
 .TP
 .B Summary
-Remove one staged file or recursively unstage staged files under a directory.
+Remove one staged file, recursively unstage staged files under a directory, or unstage all staged files.
 .TP
 .B Usage
 .nf
-omohi rm <path>...
+omohi rm [\-a|\-\-all] [<path>...]
 .fi
 .TP
 .B Positionals
 .RS 4
 .B path
-required, repeatable: Path to the staged file or directory to unstage.
+optional, repeatable: Path to the staged file or directory to unstage.
+.RE
+.TP
+.B Options
+.RS 4
+.B \-a, \-\-all
+optional: Unstage all currently staged files.
 .RE
 .TP
 .B Examples
@@ -150,11 +156,18 @@ required, repeatable: Path to the staged file or directory to unstage.
 omohi rm /tmp/note.txt
 omohi rm .
 omohi rm ./*.md
+omohi rm \-a
 .fi
 .TP
 .B Notes
 .RS 4
 When a directory is given, staged files under it are unstaged recursively.
+.RE
+.RS 4
+`\-a` and `\-\-all` unstage every currently staged file.
+.RE
+.RS 4
+`\-a` and explicit paths cannot be combined.
 .RE
 .RS 4
 Untracked, non\-staged, and non\-regular entries are skipped.

--- a/src/app/cli/command/rm.zig
+++ b/src/app/cli/command/rm.zig
@@ -12,6 +12,14 @@ pub fn run(allocator: std.mem.Allocator, args: parser_types.RmArgs) !command_typ
     var omohi = try environment.openOmohiDir(allocator, false);
     defer omohi.deinit(allocator);
 
+    if (args.all) {
+        var outcome = try rm_ops.rmAllStaged(allocator, omohi.dir);
+        defer rm_ops.freeRmOutcome(allocator, &outcome);
+
+        const output = try presenter.rmMultiResult(allocator, &outcome);
+        return .{ .output = output, .to_stderr = false, .exit_code = exit_code.ok };
+    }
+
     if (args.paths.len == 1) {
         const absolute_path = try path_resolver.resolveAbsolutePath(allocator, args.paths[0]);
         defer allocator.free(absolute_path);

--- a/src/app/cli/command_catalog.zig
+++ b/src/app/cli/command_catalog.zig
@@ -105,15 +105,19 @@ pub const all = [_]CommandSpec{
     },
     .{
         .name = "rm",
-        .usage = "rm <path>...",
-        .summary = "Remove one staged file or recursively unstage staged files under a directory.",
+        .usage = "rm [-a|--all] [<path>...]",
+        .summary = "Remove one staged file, recursively unstage staged files under a directory, or unstage all staged files.",
         .positionals = &.{
-            .{ .name = "path", .required = true, .repeatable = true, .description = "Path to the staged file or directory to unstage." },
+            .{ .name = "path", .required = false, .repeatable = true, .description = "Path to the staged file or directory to unstage." },
         },
-        .options = &.{},
-        .examples = &.{ "omohi rm /tmp/note.txt", "omohi rm .", "omohi rm ./*.md" },
+        .options = &.{
+            .{ .long = "all", .short = 'a', .value_name = null, .required = false, .repeatable = false, .description = "Unstage all currently staged files." },
+        },
+        .examples = &.{ "omohi rm /tmp/note.txt", "omohi rm .", "omohi rm ./*.md", "omohi rm -a" },
         .notes = &.{
             "When a directory is given, staged files under it are unstaged recursively.",
+            "`-a` and `--all` unstage every currently staged file.",
+            "`-a` and explicit paths cannot be combined.",
             "Untracked, non-staged, and non-regular entries are skipped.",
             "Shell-expanded multiple paths are accepted and processed in order.",
         },
@@ -460,6 +464,7 @@ fn assertDelimitedValuesMatchEnum(
 fn optionTakesValue(comptime command_name: []const u8, comptime option_long: []const u8) bool {
     if (std.mem.eql(u8, command_name, "untrack") and std.mem.eql(u8, option_long, "missing")) return false;
     if (std.mem.eql(u8, command_name, "add") and std.mem.eql(u8, option_long, "all")) return false;
+    if (std.mem.eql(u8, command_name, "rm") and std.mem.eql(u8, option_long, "all")) return false;
     if (std.mem.eql(u8, command_name, "commit") and std.mem.eql(u8, option_long, "dry-run")) return false;
     if (std.mem.eql(u8, command_name, "commit") and std.mem.eql(u8, option_long, "empty")) return false;
     if (std.mem.eql(u8, command_name, "commit") and std.mem.eql(u8, option_long, "message")) return true;

--- a/src/app/cli/parser/parse.zig
+++ b/src/app/cli/parser/parse.zig
@@ -230,10 +230,51 @@ fn parseAdd(args: []const []const u8) !types.ParsedRequest {
     return .{ .add = .{ .all = false, .paths = paths } };
 }
 
-// Parses `rm <path>...`.
+// Parses `rm <path>...` and `rm -a|--all`.
 fn parseRm(args: []const []const u8) !types.ParsedRequest {
-    if (args.len == 0) return error.MissingArgument;
-    return .{ .rm = .{ .paths = args } };
+    var all = false;
+    var idx: usize = 0;
+    var stop_option = false;
+    var positional_start: ?usize = null;
+
+    while (idx < args.len) : (idx += 1) {
+        const token = args[idx];
+
+        if (!stop_option and scan.isDoubleDash(token)) {
+            stop_option = true;
+            if (positional_start == null) positional_start = idx + 1;
+            continue;
+        }
+
+        if (!stop_option) {
+            if (scan.parseLongOption(token)) |opt| {
+                if (scan.equalsIgnoreAsciiCase(opt.key, "all")) {
+                    if (opt.value != null) return error.UnknownOption;
+                    if (all) return error.UnexpectedArgument;
+                    all = true;
+                    continue;
+                }
+                return error.UnknownOption;
+            }
+
+            if (scan.isShortOption(token, 'a')) {
+                if (all) return error.UnexpectedArgument;
+                all = true;
+                continue;
+            }
+        }
+
+        if (positional_start == null) positional_start = idx;
+    }
+
+    const paths = if (positional_start) |start| args[start..] else &.{};
+    if (all) {
+        if (paths.len != 0) return error.UnexpectedArgument;
+        return .{ .rm = .{ .all = true, .paths = paths } };
+    }
+
+    if (paths.len == 0) return error.MissingArgument;
+    return .{ .rm = .{ .all = false, .paths = paths } };
 }
 
 // Parses `journal` with no extra arguments.
@@ -613,6 +654,7 @@ test "parser accepts multiple positional paths for track add and rm" {
 
         switch (parsed) {
             .rm => |args| {
+                try std.testing.expect(!args.all);
                 try std.testing.expectEqual(@as(usize, 2), args.paths.len);
                 try std.testing.expectEqualStrings("./a.md", args.paths[0]);
                 try std.testing.expectEqualStrings("./b.md", args.paths[1]);
@@ -675,6 +717,61 @@ test "parser rejects add all mixed with paths" {
     try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "add", "-a", "./a.md" }));
     try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "add", "--all", "./a.md" }));
     try std.testing.expectError(error.UnknownOption, parseArgs(allocator, &.{ "add", "--all=value" }));
+}
+
+test "parser accepts rm all options" {
+    const allocator = std.testing.allocator;
+
+    {
+        const argv = [_][]const u8{ "rm", "-a" };
+        var parsed = try parseArgs(allocator, &argv);
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .rm => |args| {
+                try std.testing.expect(args.all);
+                try std.testing.expectEqual(@as(usize, 0), args.paths.len);
+            },
+            else => return error.UnexpectedResult,
+        }
+    }
+
+    {
+        const argv = [_][]const u8{ "rm", "--all" };
+        var parsed = try parseArgs(allocator, &argv);
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .rm => |args| {
+                try std.testing.expect(args.all);
+                try std.testing.expectEqual(@as(usize, 0), args.paths.len);
+            },
+            else => return error.UnexpectedResult,
+        }
+    }
+
+    {
+        const argv = [_][]const u8{ "rm", "--", "--all" };
+        var parsed = try parseArgs(allocator, &argv);
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .rm => |args| {
+                try std.testing.expect(!args.all);
+                try std.testing.expectEqual(@as(usize, 1), args.paths.len);
+                try std.testing.expectEqualStrings("--all", args.paths[0]);
+            },
+            else => return error.UnexpectedResult,
+        }
+    }
+}
+
+test "parser rejects rm all mixed with paths" {
+    const allocator = std.testing.allocator;
+
+    try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "rm", "-a", "./a.md" }));
+    try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "rm", "--all", "./a.md" }));
+    try std.testing.expectError(error.UnknownOption, parseArgs(allocator, &.{ "rm", "--all=value" }));
 }
 
 test "parser accepts untrack id and missing option" {

--- a/src/app/cli/parser/types.zig
+++ b/src/app/cli/parser/types.zig
@@ -43,6 +43,7 @@ pub const AddArgs = struct {
 };
 
 pub const RmArgs = struct {
+    all: bool,
     paths: []const []const u8,
 };
 

--- a/src/app/cli/runtime/journal_adapter.zig
+++ b/src/app/cli/runtime/journal_adapter.zig
@@ -23,7 +23,7 @@ pub fn fromParsedRequest(
             .missing = args.missing,
         }),
         .add => |args| try makeEvent(allocator, "add", .{ .all = args.all, .paths = args.paths }),
-        .rm => |args| try makeEvent(allocator, "rm", .{ .paths = args.paths }),
+        .rm => |args| try makeEvent(allocator, "rm", .{ .all = args.all, .paths = args.paths }),
         .commit => |args| blk: {
             if (args.dry_run) break :blk null;
             break :blk try makeEvent(allocator, "commit", .{

--- a/src/ops/completion_ops.zig
+++ b/src/ops/completion_ops.zig
@@ -11,6 +11,7 @@ const top_level_aliases = [_][]const u8{ "-h", "--help", "-v", "--version" };
 const tag_commands = [_][]const u8{ "ls", "add", "rm" };
 const commit_options = [_][]const u8{ "-e", "--empty", "-m", "--message", "-t", "--tag", "--dry-run" };
 const add_options = [_][]const u8{ "-a", "--all" };
+const rm_options = [_][]const u8{ "-a", "--all" };
 const untrack_options = [_][]const u8{"--missing"};
 const tracklist_options = [_][]const u8{ "--output", "--field" };
 const find_options = [_][]const u8{ "-t", "--tag", "--empty", "--no-empty", "-s", "--since", "-u", "--until", "--limit", "--output", "--field" };
@@ -29,7 +30,7 @@ pub fn requiresStore(words: []const []const u8, index: usize) bool {
     const command = words[1];
     if (std.mem.eql(u8, command, "untrack")) return index == 2;
     if (std.mem.eql(u8, command, "show")) return showExpectsCommitId(words, index);
-    if (std.mem.eql(u8, command, "rm")) return index == 2;
+    if (std.mem.eql(u8, command, "rm")) return index == 2 and !isOptionLike(words[index]);
     if (std.mem.eql(u8, command, "find")) return expectsValue(words, index, "--tag", "-t");
     if (std.mem.eql(u8, command, "commit")) return expectsValue(words, index, "--tag", "-t");
 
@@ -145,6 +146,8 @@ pub fn complete(
         return out;
     }
     if (std.mem.eql(u8, command, "rm") and index == 2) {
+        try appendFilteredStatic(allocator, &out, &rm_options, current);
+        if (isOptionLike(current)) return out;
         if (maybe_omohi_dir) |omohi_dir| {
             var paths = try loadStagedPaths(allocator, omohi_dir);
             defer freeCandidateList(allocator, &paths);
@@ -319,6 +322,11 @@ fn expectsValue(words: []const []const u8, index: usize, long: []const u8, short
     return std.mem.eql(u8, prev, long) or (short.len != 0 and std.mem.eql(u8, prev, short));
 }
 
+// Reports whether the current completion token should be treated as an option prefix.
+fn isOptionLike(token: []const u8) bool {
+    return std.mem.startsWith(u8, token, "-");
+}
+
 // Reports whether the current completion slot is the positional commit id for `show`.
 fn showExpectsCommitId(words: []const []const u8, index: usize) bool {
     if (index < 2 or index >= words.len) return false;
@@ -413,7 +421,7 @@ test "complete returns commit ids for show and tags for tag rm" {
     }
 }
 
-test "complete returns staged paths for rm" {
+test "complete returns rm options and staged paths" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -435,20 +443,35 @@ test "complete returns staged paths for rm" {
     var list = try complete(allocator, omohi_dir, &words, 2);
     defer freeCandidateList(allocator, &list);
 
-    try std.testing.expectEqual(@as(usize, 2), list.items.len);
-    try std.testing.expectEqualStrings(a_path, list.items[0]);
-    try std.testing.expectEqualStrings(b_path, list.items[1]);
-}
-
-test "complete returns add options" {
-    const allocator = std.testing.allocator;
-    const words = [_][]const u8{ "omohi", "add", "" };
-    var list = try complete(allocator, null, &words, 2);
-    defer freeCandidateList(allocator, &list);
-
-    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqual(@as(usize, 4), list.items.len);
     try std.testing.expectEqualStrings("-a", list.items[0]);
     try std.testing.expectEqualStrings("--all", list.items[1]);
+    try std.testing.expectEqualStrings(a_path, list.items[2]);
+    try std.testing.expectEqualStrings(b_path, list.items[3]);
+}
+
+test "complete returns add and rm options" {
+    const allocator = std.testing.allocator;
+
+    {
+        const words = [_][]const u8{ "omohi", "add", "" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+
+        try std.testing.expectEqual(@as(usize, 2), list.items.len);
+        try std.testing.expectEqualStrings("-a", list.items[0]);
+        try std.testing.expectEqualStrings("--all", list.items[1]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "rm", "-" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+
+        try std.testing.expectEqual(@as(usize, 2), list.items.len);
+        try std.testing.expectEqualStrings("-a", list.items[0]);
+        try std.testing.expectEqualStrings("--all", list.items[1]);
+    }
 }
 
 test "complete returns journal for top-level command and help topic" {

--- a/src/ops/rm_ops.zig
+++ b/src/ops/rm_ops.zig
@@ -20,6 +20,15 @@ pub fn rm(
     return rmDirectory(allocator, omohi_dir, absolute_path);
 }
 
+/// Removes all current staged entries.
+pub fn rmAllStaged(
+    allocator: std.mem.Allocator,
+    omohi_dir: std.fs.Dir,
+) !RmOutcome {
+    try store_api.ensureStoreVersion(allocator, omohi_dir);
+    return store_api.rmAllStaged(allocator, omohi_dir);
+}
+
 // Releases all owned unstaged path strings stored in the outcome.
 pub fn freeRmOutcome(allocator: std.mem.Allocator, outcome: *RmOutcome) void {
     store_api.freeRmBatchOutcome(allocator, outcome);
@@ -146,4 +155,46 @@ test "rm removes staged files recursively and skips non-staged files under direc
     try std.testing.expectEqual(@as(usize, 1), outcome.unstaged_paths.items.len);
     try std.testing.expectEqual(@as(usize, 1), outcome.skipped_not_staged);
     try std.testing.expectEqual(@as(usize, 1), outcome.skipped_untracked);
+}
+
+test "rmAllStaged removes every staged entry" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var source_dir = try tmp.dir.makeOpenPath("src", .{ .iterate = true, .access_sub_paths = true });
+    defer source_dir.close();
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try store_api.initializeVersionForFirstTrack(allocator, omohi_dir);
+
+    const a_path = try createTestFileAndResolve(source_dir, allocator, "a.txt", "a");
+    defer allocator.free(a_path);
+    const b_path = try createTestFileAndResolve(source_dir, allocator, "b.txt", "b");
+    defer allocator.free(b_path);
+
+    _ = try store_api.track(allocator, omohi_dir, a_path);
+    _ = try store_api.track(allocator, omohi_dir, b_path);
+    try store_api.add(allocator, omohi_dir, a_path);
+    try store_api.add(allocator, omohi_dir, b_path);
+
+    var outcome = try rmAllStaged(allocator, omohi_dir);
+    defer freeRmOutcome(allocator, &outcome);
+
+    try std.testing.expectEqual(@as(usize, 2), outcome.unstaged_paths.items.len);
+    try std.testing.expectEqual(.tracked, try store_api.statusForTrackedPath(allocator, omohi_dir, a_path));
+    try std.testing.expectEqual(.tracked, try store_api.statusForTrackedPath(allocator, omohi_dir, b_path));
+}
+
+// Creates one test file under the fixture directory and returns its owned absolute path.
+fn createTestFileAndResolve(
+    dir: std.fs.Dir,
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    contents: []const u8,
+) ![]u8 {
+    var file = try dir.createFile(path, .{});
+    defer file.close();
+    try file.writeAll(contents);
+    return try dir.realpathAlloc(allocator, path);
 }

--- a/src/store/api.zig
+++ b/src/store/api.zig
@@ -385,6 +385,24 @@ pub fn rmTree(
     return outcome;
 }
 
+/// Removes all current staged entries.
+/// Memory: owned result, free with freeRmBatchOutcome
+/// Lifetime: valid until caller frees the returned lists
+/// Errors: lock/I/O errors plus staged entry validation errors
+pub fn rmAllStaged(
+    allocator: std.mem.Allocator,
+    omohi_dir: std.fs.Dir,
+) !RmBatchOutcome {
+    try lock.acquireLock(omohi_dir);
+    defer lock.releaseLock(omohi_dir);
+
+    const persistence = PersistenceLayout.init(omohi_dir);
+    var raw_entries = try loadRawStagedEntriesOrEmpty(allocator, persistence);
+    defer if (raw_entries) |*list| local_staged.freeRawEntries(allocator, list);
+
+    return rmAllStagedLocked(allocator, persistence, raw_entries);
+}
+
 /// Registers an absolute file path under tracked/<TrackedFileId>.
 /// Memory: borrowed (temporary allocations only)
 /// Errors: error{AlreadyTracked} plus lock/I/O and constrained type errors.
@@ -1229,6 +1247,40 @@ fn rmPathsLocked(
         try outcome.unstaged_paths.append(try allocator.dupe(u8, absolute_path));
     }
 
+    return outcome;
+}
+
+// Removes every valid raw staged entry while the caller already holds the store lock.
+fn rmAllStagedLocked(
+    allocator: std.mem.Allocator,
+    persistence: PersistenceLayout,
+    raw_entries: ?local_staged.RawEntryList,
+) !RmBatchOutcome {
+    var outcome = RmBatchOutcome.init(allocator);
+    errdefer freeRmBatchOutcome(allocator, &outcome);
+
+    var staged_hash_counts = std.AutoHashMap([64]u8, usize).init(allocator);
+    defer staged_hash_counts.deinit();
+
+    if (raw_entries) |list| {
+        for (list.items) |entry| {
+            const content_hash = entry.content_hash orelse continue;
+            try incrementHashCount(&staged_hash_counts, content_hash);
+        }
+
+        for (list.items) |entry| {
+            const absolute_path = entry.path orelse continue;
+            const content_hash = entry.content_hash orelse continue;
+            const file_name = try constrained_types.StagedFileId.init(entry.file_name);
+
+            _ = try constrained_types.TrackedFilePath.init(absolute_path);
+            try local_trash.moveStagedEntryToTrash(allocator, persistence, file_name.asSlice());
+            try decrementHashCountAndTrashObject(allocator, persistence, &staged_hash_counts, content_hash);
+            try outcome.unstaged_paths.append(try allocator.dupe(u8, absolute_path));
+        }
+    }
+
+    std.mem.sort([]u8, outcome.unstaged_paths.items, {}, isStringAscLessThan);
     return outcome;
 }
 
@@ -2736,6 +2788,79 @@ test "rmTree removes staged files recursively and counts non-regular entries" {
 
     try std.testing.expectEqual(@as(usize, 2), outcome.unstaged_paths.items.len);
     try std.testing.expectEqual(@as(usize, 1), outcome.skipped_non_regular);
+}
+
+test "rmAllStaged removes all staged entries and staged objects" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var source_dir = try tmp.dir.makeOpenPath("src", .{ .iterate = true, .access_sub_paths = true });
+    defer source_dir.close();
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try initializeVersionForFirstTrack(allocator, omohi_dir);
+
+    {
+        var file = try source_dir.createFile("a.txt", .{});
+        defer file.close();
+        try file.writeAll("a");
+    }
+    {
+        var file = try source_dir.createFile("b.txt", .{});
+        defer file.close();
+        try file.writeAll("b");
+    }
+
+    const a_path = try source_dir.realpathAlloc(allocator, "a.txt");
+    defer allocator.free(a_path);
+    const b_path = try source_dir.realpathAlloc(allocator, "b.txt");
+    defer allocator.free(b_path);
+
+    _ = try track(allocator, omohi_dir, a_path);
+    _ = try track(allocator, omohi_dir, b_path);
+    try add(allocator, omohi_dir, a_path);
+    try add(allocator, omohi_dir, b_path);
+
+    var outcome = try rmAllStaged(allocator, omohi_dir);
+    defer freeRmBatchOutcome(allocator, &outcome);
+
+    try std.testing.expectEqual(@as(usize, 2), outcome.unstaged_paths.items.len);
+    try fixture_inspector.expectDirHasNoFiles(omohi_dir, "staged/entries");
+    try fixture_inspector.expectDirHasNoFiles(omohi_dir, "staged/objects");
+}
+
+test "rmAllStaged unstages a deleted source file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var source_dir = try tmp.dir.makeOpenPath("src", .{ .iterate = true, .access_sub_paths = true });
+    defer source_dir.close();
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try initializeVersionForFirstTrack(allocator, omohi_dir);
+
+    {
+        var file = try source_dir.createFile("deleted.txt", .{});
+        defer file.close();
+        try file.writeAll("deleted");
+    }
+
+    const absolute_path = try source_dir.realpathAlloc(allocator, "deleted.txt");
+    defer allocator.free(absolute_path);
+
+    _ = try track(allocator, omohi_dir, absolute_path);
+    try add(allocator, omohi_dir, absolute_path);
+    try source_dir.deleteFile("deleted.txt");
+
+    var outcome = try rmAllStaged(allocator, omohi_dir);
+    defer freeRmBatchOutcome(allocator, &outcome);
+
+    try std.testing.expectEqual(@as(usize, 1), outcome.unstaged_paths.items.len);
+    try std.testing.expectEqualStrings(absolute_path, outcome.unstaged_paths.items[0]);
+    try fixture_inspector.expectDirHasNoFiles(omohi_dir, "staged/entries");
+    try fixture_inspector.expectDirHasNoFiles(omohi_dir, "staged/objects");
 }
 
 test "find sorts by createdAt desc and applies the requested limit" {


### PR DESCRIPTION
## Summary

Added `rm` command `--all` / `-a` options.

## Related Issue

## Testing

- [x] Tests run
- [ ] Not run

List the tests or checks you ran.
If you did not run them, explain why.

## Docs

- [x] Docs updated
- [ ] N/A

List updated docs if applicable.

## Checklist

- [x] The change is small and focused.
- [x] I completed the Testing section.
- [x] I completed the Docs section.
- [x] I called out any breaking change in this PR description.
