### PR TITLE
Modified journal command outputs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,6 +231,7 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
   - `omohi journal`
 - Notes:
   - Shows the latest 500 successful mutating command records.
+  - Displays timestamps in the local timezone.
   - TTY output is paged with less when available.
 
 ### tag ls

--- a/docs/man/omohi.1
+++ b/docs/man/omohi.1
@@ -450,6 +450,9 @@ omohi journal
 Shows the latest 500 successful mutating command records.
 .RE
 .RS 4
+Displays timestamps in the local timezone.
+.RE
+.RS 4
 TTY output is paged with less when available.
 .RE
 .SS tag ls

--- a/src/app/cli/command/journal.zig
+++ b/src/app/cli/command/journal.zig
@@ -18,51 +18,13 @@ pub fn run(allocator: std.mem.Allocator, args: parser_types.JournalArgs) !comman
     var lines = try journal_ops.journal(allocator, omohi.dir, default_limit);
     defer journal_ops.freeJournalList(allocator, &lines);
 
-    const output = try journalResult(allocator, &lines);
+    const output = try presenter.journalResult(allocator, &lines);
     return .{
         .output = output,
         .to_stderr = false,
         .exit_code = exit_code.ok,
         .page_output = true,
     };
-}
-
-// Renders journal lines into owned output and returns a fallback message when empty.
-fn journalResult(allocator: std.mem.Allocator, lines: *const journal_ops.JournalList) ![]u8 {
-    if (lines.items.len == 0) return presenter.message(allocator, "no journal entries\n");
-
-    var out = std.array_list.Managed(u8).init(allocator);
-    errdefer out.deinit();
-    const writer = out.writer();
-
-    for (lines.items) |line| {
-        try writer.print("{s}\n", .{line});
-    }
-
-    return out.toOwnedSlice();
-}
-
-test "journalResult formats lines with trailing newlines" {
-    var lines = journal_ops.JournalList.init(std.testing.allocator);
-    defer journal_ops.freeJournalList(std.testing.allocator, &lines);
-
-    try lines.append(try std.testing.allocator.dupe(u8, "line-a"));
-    try lines.append(try std.testing.allocator.dupe(u8, "line-b"));
-
-    const output = try journalResult(std.testing.allocator, &lines);
-    defer std.testing.allocator.free(output);
-
-    try std.testing.expectEqualStrings("line-a\nline-b\n", output);
-}
-
-test "journalResult returns empty message when no entries exist" {
-    var lines = journal_ops.JournalList.init(std.testing.allocator);
-    defer journal_ops.freeJournalList(std.testing.allocator, &lines);
-
-    const output = try journalResult(std.testing.allocator, &lines);
-    defer std.testing.allocator.free(output);
-
-    try std.testing.expectEqualStrings("no journal entries\n", output);
 }
 
 test "journal uses 500 item limit" {

--- a/src/app/cli/command_catalog.zig
+++ b/src/app/cli/command_catalog.zig
@@ -252,6 +252,7 @@ pub const all = [_]CommandSpec{
         .examples = &.{"omohi journal"},
         .notes = &.{
             "Shows the latest 500 successful mutating command records.",
+            "Displays timestamps in the local timezone.",
             "TTY output is paged with less when available.",
         },
     },

--- a/src/app/cli/presenter/output.zig
+++ b/src/app/cli/presenter/output.zig
@@ -9,6 +9,7 @@ const status_ops = @import("../../../ops/status_ops.zig");
 const find_ops = @import("../../../ops/find_ops.zig");
 const show_ops = @import("../../../ops/show_ops.zig");
 const tag_ops = @import("../../../ops/tag_ops.zig");
+const journal_ops = @import("../../../ops/journal_ops.zig");
 
 pub const TagRemoveOutcome = enum {
     no_tags,
@@ -241,6 +242,28 @@ pub fn rmMultiResult(allocator: std.mem.Allocator, outcome: *const rm_ops.RmOutc
 // Renders the created commit id as owned CLI output.
 pub fn commitResult(allocator: std.mem.Allocator, commit_id: [64]u8) ![]u8 {
     return std.fmt.allocPrint(allocator, "Committed {s}.\n", .{&commit_id});
+}
+
+// Renders journal entries as owned CLI output.
+pub fn journalResult(
+    allocator: std.mem.Allocator,
+    entries: *const journal_ops.JournalList,
+) ![]u8 {
+    if (entries.items.len == 0) return message(allocator, "no journal entries\n");
+
+    var out = std.array_list.Managed(u8).init(allocator);
+    errdefer out.deinit();
+    const writer = out.writer();
+
+    for (entries.items) |entry| {
+        try writer.print("{s} {s} {s}\n", .{
+            entry.local_ts,
+            entry.command_type,
+            entry.payload_json,
+        });
+    }
+
+    return out.toOwnedSlice();
 }
 
 // Renders tracked entries as owned CLI output.
@@ -1163,6 +1186,42 @@ test "findResult renders heading and commit blocks" {
             "  first\n\n",
         output,
     );
+}
+
+test "journalResult renders local timestamp, command type, and payload" {
+    var entries = journal_ops.JournalList.init(std.testing.allocator);
+    defer journal_ops.freeJournalList(std.testing.allocator, &entries);
+
+    try entries.append(.{
+        .local_ts = try std.testing.allocator.dupe(u8, "2026-03-10T09:00:00.000+09:00"),
+        .command_type = try std.testing.allocator.dupe(u8, "track"),
+        .payload_json = try std.testing.allocator.dupe(u8, "{\"path\":\"/tmp/one\"}"),
+    });
+    try entries.append(.{
+        .local_ts = try std.testing.allocator.dupe(u8, "2026-03-10T09:00:01.000+09:00"),
+        .command_type = try std.testing.allocator.dupe(u8, "add"),
+        .payload_json = try std.testing.allocator.dupe(u8, "{\"message\":\"hello world\"}"),
+    });
+
+    const output = try journalResult(std.testing.allocator, &entries);
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expectEqualStrings(
+        "2026-03-10T09:00:00.000+09:00 track {\"path\":\"/tmp/one\"}\n" ++
+            "2026-03-10T09:00:01.000+09:00 add {\"message\":\"hello world\"}\n",
+        output,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, output, "2026-03-10T00:00:00.000Z") == null);
+}
+
+test "journalResult renders empty message when no entries exist" {
+    var entries = journal_ops.JournalList.init(std.testing.allocator);
+    defer journal_ops.freeJournalList(std.testing.allocator, &entries);
+
+    const output = try journalResult(std.testing.allocator, &entries);
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expectEqualStrings("no journal entries\n", output);
 }
 
 test "findResult renders selected fields as text rows" {

--- a/src/ops/journal_ops.zig
+++ b/src/ops/journal_ops.zig
@@ -2,9 +2,10 @@ const std = @import("std");
 
 const store_api = @import("../store/api.zig");
 
-pub const JournalList = store_api.StringList;
+pub const JournalEntry = store_api.JournalEntry;
+pub const JournalList = store_api.JournalEntryList;
 
-/// Loads recent journal lines from the store.
+/// Loads recent journal entries from the store.
 pub fn journal(
     allocator: std.mem.Allocator,
     omohi_dir: std.fs.Dir,
@@ -14,12 +15,12 @@ pub fn journal(
     return store_api.journal(allocator, omohi_dir, limit);
 }
 
-// Releases the owned journal lines returned by `journal`.
+// Releases the owned journal entries returned by `journal`.
 pub fn freeJournalList(allocator: std.mem.Allocator, list: *JournalList) void {
-    store_api.freeStringList(allocator, list);
+    store_api.freeJournalEntryList(allocator, list);
 }
 
-test "journal delegates to store and returns recent lines" {
+test "journal delegates to store and returns recent entries" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -34,5 +35,6 @@ test "journal delegates to store and returns recent lines" {
     defer freeJournalList(allocator, &lines);
 
     try std.testing.expectEqual(@as(usize, 1), lines.items.len);
-    try std.testing.expect(std.mem.indexOf(u8, lines.items[0], "\"/tmp/ops\"") != null);
+    try std.testing.expectEqualStrings("track", lines.items[0].command_type);
+    try std.testing.expect(std.mem.indexOf(u8, lines.items[0].payload_json, "\"/tmp/ops\"") != null);
 }

--- a/src/store/api.zig
+++ b/src/store/api.zig
@@ -114,6 +114,12 @@ pub const StringList = std.array_list.Managed([]u8);
 /// Owns a list of heap-allocated tag strings.
 pub const TagList = StringList;
 
+/// Describes one journal entry as presented to upper layers.
+pub const JournalEntry = local_journal.JournalEntry;
+
+/// Owns journal entries returned by `journal`.
+pub const JournalEntryList = local_journal.JournalEntryList;
+
 /// Carries commit metadata, entries, and tags for `show`.
 pub const CommitDetails = struct {
     commit_id: constrained_types.CommitId,
@@ -768,15 +774,20 @@ pub fn freeStringList(allocator: std.mem.Allocator, list: *StringList) void {
     list.deinit();
 }
 
-/// Loads latest journal lines in reverse chronological order.
-/// Memory: owned list, free with freeStringList.
+/// Loads latest journal entries in reverse chronological order.
+/// Memory: owned list, free with freeJournalEntryList.
 pub fn journal(
     allocator: std.mem.Allocator,
     omohi_dir: std.fs.Dir,
     limit: usize,
-) !StringList {
+) !JournalEntryList {
     const persistence = PersistenceLayout.init(omohi_dir);
-    return local_journal.readLatestLines(allocator, persistence, limit);
+    return local_journal.readLatestEntries(allocator, persistence, limit);
+}
+
+/// Releases the owned journal entries stored in the list.
+pub fn freeJournalEntryList(allocator: std.mem.Allocator, list: *JournalEntryList) void {
+    local_journal.freeEntryList(allocator, list);
 }
 
 // Adds tags to a commit, creating missing tag records and updating commit-tag metadata under the lock.
@@ -3139,7 +3150,7 @@ test "appendJournal writes one line into UTC daily file" {
     try std.testing.expect(std.mem.indexOf(u8, bytes, "{\"path\":\"/tmp/sample\"}") != null);
 }
 
-test "journal returns latest lines in reverse chronological order" {
+test "journal returns latest entries in reverse chronological order" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -3152,11 +3163,13 @@ test "journal returns latest lines in reverse chronological order" {
     try appendJournal(allocator, omohi_dir, "add", "{\"path\":\"/tmp/two\"}");
 
     var lines = try journal(allocator, omohi_dir, 2);
-    defer freeStringList(allocator, &lines);
+    defer freeJournalEntryList(allocator, &lines);
 
     try std.testing.expectEqual(@as(usize, 2), lines.items.len);
-    try std.testing.expect(std.mem.indexOf(u8, lines.items[0], "\"/tmp/two\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, lines.items[1], "\"/tmp/one\"") != null);
+    try std.testing.expectEqualStrings("add", lines.items[0].command_type);
+    try std.testing.expect(std.mem.indexOf(u8, lines.items[0].payload_json, "\"/tmp/two\"") != null);
+    try std.testing.expectEqualStrings("track", lines.items[1].command_type);
+    try std.testing.expect(std.mem.indexOf(u8, lines.items[1].payload_json, "\"/tmp/one\"") != null);
 }
 
 test "commit rejects staged entry when corresponding object is missing" {

--- a/src/store/local/journal.zig
+++ b/src/store/local/journal.zig
@@ -5,7 +5,6 @@ const PersistenceLayout = @import("../object/persistence_layout.zig").Persistenc
 
 const max_journal_file_size = 64 * 1024 * 1024;
 const journal_format_version: u32 = 1;
-const JournalLineList = std.array_list.Managed([]u8);
 
 pub const JournalRecord = struct {
     ts_utc: [24]u8,
@@ -13,6 +12,21 @@ pub const JournalRecord = struct {
     command_type: []const u8,
     payload_json: []const u8,
 };
+
+pub const JournalEntry = struct {
+    local_ts: []u8,
+    command_type: []u8,
+    payload_json: []u8,
+
+    /// Releases the owned fields of one journal entry.
+    pub fn deinit(self: *JournalEntry, allocator: std.mem.Allocator) void {
+        allocator.free(self.local_ts);
+        allocator.free(self.command_type);
+        allocator.free(self.payload_json);
+    }
+};
+
+pub const JournalEntryList = std.array_list.Managed(JournalEntry);
 
 /// Appends one journal record into daily UTC journal file.
 pub fn appendRecord(
@@ -48,14 +62,14 @@ pub fn appendRecord(
     try atomic_write.atomicWrite(allocator, persistence.dir, path, line);
 }
 
-/// Loads latest journal lines in reverse chronological order.
-pub fn readLatestLines(
+/// Loads latest journal entries in reverse chronological order.
+pub fn readLatestEntries(
     allocator: std.mem.Allocator,
     persistence: PersistenceLayout,
     limit: usize,
-) !JournalLineList {
-    var out = JournalLineList.init(allocator);
-    errdefer freeStringList(allocator, &out);
+) !JournalEntryList {
+    var out = JournalEntryList.init(allocator);
+    errdefer freeEntryList(allocator, &out);
 
     if (limit == 0) return out;
 
@@ -65,8 +79,8 @@ pub fn readLatestLines(
     };
     defer journal_dir.close();
 
-    var names = JournalLineList.init(allocator);
-    defer freeStringList(allocator, &names);
+    var names = std.array_list.Managed([]u8).init(allocator);
+    defer freeNameList(allocator, &names);
 
     var it = journal_dir.iterate();
     while (try it.next()) |entry| {
@@ -84,16 +98,16 @@ pub fn readLatestLines(
         const bytes = try persistence.dir.readFileAlloc(allocator, path, max_journal_file_size);
         defer allocator.free(bytes);
 
-        try appendLatestLinesFromBytes(allocator, &out, bytes, limit);
+        try appendLatestEntriesFromBytes(allocator, &out, bytes, limit);
         if (out.items.len >= limit) break;
     }
 
     return out;
 }
 
-// Releases the owned journal lines stored in the list.
-pub fn freeStringList(allocator: std.mem.Allocator, list: *JournalLineList) void {
-    for (list.items) |item| allocator.free(item);
+// Releases the owned journal entries stored in the list.
+pub fn freeEntryList(allocator: std.mem.Allocator, list: *JournalEntryList) void {
+    for (list.items) |*item| item.deinit(allocator);
     list.deinit();
 }
 
@@ -125,10 +139,16 @@ fn isNameDescLessThan(_: void, lhs: []u8, rhs: []u8) bool {
     return std.mem.order(u8, lhs, rhs) == .gt;
 }
 
-// Appends newest lines from one journal file into the output list until the limit is reached.
-fn appendLatestLinesFromBytes(
+// Releases the owned journal file names stored in the list.
+fn freeNameList(allocator: std.mem.Allocator, list: *std.array_list.Managed([]u8)) void {
+    for (list.items) |item| allocator.free(item);
+    list.deinit();
+}
+
+// Appends newest journal entries from one file into the output list until the limit is reached.
+fn appendLatestEntriesFromBytes(
     allocator: std.mem.Allocator,
-    out: *JournalLineList,
+    out: *JournalEntryList,
     bytes: []const u8,
     limit: usize,
 ) !void {
@@ -140,13 +160,42 @@ fn appendLatestLinesFromBytes(
         var start = line_end;
         while (start > 0 and bytes[start - 1] != '\n') : (start -= 1) {}
 
-        if (line_end > start) {
-            try out.append(try allocator.dupe(u8, bytes[start..line_end]));
-        }
+        if (line_end > start) try out.append(try parseLineOwned(allocator, bytes[start..line_end]));
 
         if (start == 0) break;
         end = start;
     }
+}
+
+// Parses one persisted journal line into an owned entry for CLI-facing presentation.
+fn parseLineOwned(allocator: std.mem.Allocator, line: []const u8) !JournalEntry {
+    const first_space = std.mem.indexOfScalar(u8, line, ' ') orelse return error.InvalidJournalRecord;
+    const second_space = std.mem.indexOfScalarPos(u8, line, first_space + 1, ' ') orelse return error.InvalidJournalRecord;
+    const third_space = std.mem.indexOfScalarPos(u8, line, second_space + 1, ' ') orelse return error.InvalidJournalRecord;
+    const fourth_space = std.mem.indexOfScalarPos(u8, line, third_space + 1, ' ') orelse return error.InvalidJournalRecord;
+
+    if (fourth_space + 1 > line.len) return error.InvalidJournalRecord;
+
+    const version_text = line[third_space + 1 .. fourth_space];
+    if (version_text.len == 0) return error.InvalidJournalRecord;
+    const version = std.fmt.parseInt(u32, version_text, 10) catch return error.InvalidJournalRecord;
+    if (version != journal_format_version) return error.InvalidJournalRecord;
+
+    const local_ts = line[first_space + 1 .. second_space];
+    const command_type = line[second_space + 1 .. third_space];
+    const payload_json = line[fourth_space + 1 ..];
+
+    const local_ts_owned = try allocator.dupe(u8, local_ts);
+    errdefer allocator.free(local_ts_owned);
+    const command_type_owned = try allocator.dupe(u8, command_type);
+    errdefer allocator.free(command_type_owned);
+    const payload_json_owned = try allocator.dupe(u8, payload_json);
+
+    return .{
+        .local_ts = local_ts_owned,
+        .command_type = command_type_owned,
+        .payload_json = payload_json_owned,
+    };
 }
 
 test "appendRecord creates and appends daily journal file" {
@@ -197,7 +246,22 @@ test "appendRecord rejects unsupported command type" {
     }));
 }
 
-test "readLatestLines returns newest records across files" {
+test "parseLineOwned extracts local timestamp, command type, and payload" {
+    const entry = try parseLineOwned(
+        std.testing.allocator,
+        "2026-03-15T00:00:01.000Z 2026-03-15T09:00:01.000+09:00 add 1 {\"message\":\"hello world\"}",
+    );
+    defer {
+        var mutable_entry = entry;
+        mutable_entry.deinit(std.testing.allocator);
+    }
+
+    try std.testing.expectEqualStrings("2026-03-15T09:00:01.000+09:00", entry.local_ts);
+    try std.testing.expectEqualStrings("add", entry.command_type);
+    try std.testing.expectEqualStrings("{\"message\":\"hello world\"}", entry.payload_json);
+}
+
+test "readLatestEntries returns newest records across files" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -212,25 +276,30 @@ test "readLatestLines returns newest records across files" {
         allocator,
         omohi_dir,
         "journal/2026-03-14.log",
-        "2026-03-14T00:00:00.000Z old-a track 1 {}\n2026-03-14T00:00:01.000Z old-b add 1 {}\n",
+        "2026-03-14T00:00:00.000Z 2026-03-14T09:00:00.000+09:00 track 1 {}\n" ++
+            "2026-03-14T00:00:01.000Z 2026-03-14T09:00:01.000+09:00 add 1 {}\n",
     );
     try atomic_write.atomicWrite(
         allocator,
         omohi_dir,
         "journal/2026-03-15.log",
-        "2026-03-15T00:00:00.000Z new-a track 1 {}\n2026-03-15T00:00:01.000Z new-b add 1 {}\n",
+        "2026-03-15T00:00:00.000Z 2026-03-15T09:00:00.000+09:00 track 1 {}\n" ++
+            "2026-03-15T00:00:01.000Z 2026-03-15T09:00:01.000+09:00 add 1 {}\n",
     );
 
-    var lines = try readLatestLines(allocator, persistence, 3);
-    defer freeStringList(allocator, &lines);
+    var lines = try readLatestEntries(allocator, persistence, 3);
+    defer freeEntryList(allocator, &lines);
 
     try std.testing.expectEqual(@as(usize, 3), lines.items.len);
-    try std.testing.expectEqualStrings("2026-03-15T00:00:01.000Z new-b add 1 {}", lines.items[0]);
-    try std.testing.expectEqualStrings("2026-03-15T00:00:00.000Z new-a track 1 {}", lines.items[1]);
-    try std.testing.expectEqualStrings("2026-03-14T00:00:01.000Z old-b add 1 {}", lines.items[2]);
+    try std.testing.expectEqualStrings("2026-03-15T09:00:01.000+09:00", lines.items[0].local_ts);
+    try std.testing.expectEqualStrings("add", lines.items[0].command_type);
+    try std.testing.expectEqualStrings("{}", lines.items[0].payload_json);
+    try std.testing.expectEqualStrings("2026-03-15T09:00:00.000+09:00", lines.items[1].local_ts);
+    try std.testing.expectEqualStrings("track", lines.items[1].command_type);
+    try std.testing.expectEqualStrings("2026-03-14T09:00:01.000+09:00", lines.items[2].local_ts);
 }
 
-test "readLatestLines returns empty when journal directory is missing" {
+test "readLatestEntries returns empty when journal directory is missing" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -239,8 +308,8 @@ test "readLatestLines returns empty when journal directory is missing" {
     defer omohi_dir.close();
 
     const persistence = PersistenceLayout.init(omohi_dir);
-    var lines = try readLatestLines(allocator, persistence, 20);
-    defer freeStringList(allocator, &lines);
+    var lines = try readLatestEntries(allocator, persistence, 20);
+    defer freeEntryList(allocator, &lines);
 
     try std.testing.expectEqual(@as(usize, 0), lines.items.len);
 }


### PR DESCRIPTION
## Summary

Changed `journal` command outputs to remove UTC date and time.
And also refactored outputs implementation to use the entry object.

## Related Issue

## Testing

- [x] Tests run
- [ ] Not run

List the tests or checks you ran.
If you did not run them, explain why.

## Docs

- [x] Docs updated
- [ ] N/A

List updated docs if applicable.

## Checklist

- [x] The change is small and focused.
- [x] I completed the Testing section.
- [x] I completed the Docs section.
- [x] I called out any breaking change in this PR description.
