### PR TITLE
Add a field option for tag list commands

### DIFF
--- a/.github/scripts/omohi_completion.sh
+++ b/.github/scripts/omohi_completion.sh
@@ -41,7 +41,13 @@ case "$*" in
     printf '%s\n' track untrack add rm commit status tracklist version find show tag help -h --help -v --version
     ;;
   "omohi tag " )
-    printf '%s\n' ls add rm
+    printf '%s\n' ls add rm --field
+    ;;
+  "omohi tag --field " )
+    printf '%s\n' tag
+    ;;
+  "omohi tag ls --field " )
+    printf '%s\n' tag
     ;;
   "omohi commit " )
     printf '%s\n' -m --message -t --tag --dry-run
@@ -130,7 +136,9 @@ assert_reply() {
 }
 
 assert_reply "track untrack add rm commit status tracklist version find show tag help -h --help -v --version" omohi ""
-assert_reply "ls add rm" omohi tag ""
+assert_reply "ls add rm --field" omohi tag ""
+assert_reply "tag" omohi tag --field ""
+assert_reply "tag" omohi tag ls --field ""
 assert_reply "-m --message -t --tag --dry-run" omohi commit ""
 assert_reply "--message" omohi commit --m
 assert_reply "-a --all" omohi add -

--- a/.github/scripts/omohi_e2e_matrix.sh
+++ b/.github/scripts/omohi_e2e_matrix.sh
@@ -1084,22 +1084,38 @@ case_082_tag_ls_with_tags() {
   assert_contains "$RUN_STDOUT" "beta" "tag ls should include beta tag"
 }
 
-case_083_tag_ls_without_tags() {
+case_083_tag_field_only() {
+  setup_commit_with_two_files_and_tags
+
+  run_omohi_capture tag --field tag
+  assert_eq "0" "$RUN_CODE" "tag --field should succeed"
+  assert_eq $'alpha\nbeta' "$RUN_STDOUT" "tag --field should print one tag per line"
+
+  run_omohi_capture tag ls --field tag "$LAST_COMMIT_ID"
+  assert_eq "0" "$RUN_CODE" "tag ls --field should succeed"
+  assert_eq $'alpha\nbeta' "$RUN_STDOUT" "tag ls --field should print one tag per line"
+}
+
+case_084_tag_ls_without_tags() {
   setup_commit_without_tags
   run_omohi_capture tag ls "$LAST_COMMIT_ID"
   assert_eq "0" "$RUN_CODE" "tag ls should succeed"
   assert_contains "$RUN_STDOUT" "Found 0 tag(s) for commit $LAST_COMMIT_ID." "tag ls should report zero tags"
   assert_contains "$RUN_STDOUT" "(none)" "tag ls should show none"
+
+  run_omohi_capture tag ls --field tag "$LAST_COMMIT_ID"
+  assert_eq "0" "$RUN_CODE" "tag ls --field should succeed for tagless commit"
+  assert_eq "" "$RUN_STDOUT" "tag ls --field should emit empty output for tagless commit"
 }
 
-case_084_tag_ls_unknown_commit() {
+case_085_tag_ls_unknown_commit() {
   setup_commit_without_tags
   run_omohi_capture tag ls 0000000000000000000000000000000000000000000000000000000000000000
   assert_eq "4" "$RUN_CODE" "tag ls should fail for unknown commit"
   assert_contains "$RUN_STDERR" "Commit not found:" "tag ls should report unknown commit"
 }
 
-case_085_tag_add_single() {
+case_086_tag_add_single() {
   setup_commit_without_tags
   run_omohi_capture tag add "$LAST_COMMIT_ID" release
   assert_eq "0" "$RUN_CODE" "tag add should succeed"
@@ -1107,7 +1123,7 @@ case_085_tag_add_single() {
   assert_contains "$RUN_STDOUT" "release" "tag add should list resulting tags"
 }
 
-case_086_tag_add_multiple() {
+case_087_tag_add_multiple() {
   setup_commit_without_tags
   run_omohi_capture tag add "$LAST_COMMIT_ID" release prod
   assert_eq "0" "$RUN_CODE" "tag add should succeed for multiple tags"
@@ -1116,7 +1132,7 @@ case_086_tag_add_multiple() {
   assert_contains "$RUN_STDOUT" "prod" "tag add should include prod tag"
 }
 
-case_087_tag_add_existing_only() {
+case_088_tag_add_existing_only() {
   setup_commit_without_tags
   run_omohi_capture tag add "$LAST_COMMIT_ID" release
   assert_eq "0" "$RUN_CODE" "first tag add should succeed"
@@ -1126,21 +1142,21 @@ case_087_tag_add_existing_only() {
   assert_contains "$RUN_STDOUT" "No new tags were added; commit $LAST_COMMIT_ID already has the specified tags." "tag add should report no-op"
 }
 
-case_088_tag_add_unknown_commit() {
+case_089_tag_add_unknown_commit() {
   setup_commit_without_tags
   run_omohi_capture tag add 0000000000000000000000000000000000000000000000000000000000000000 release
   assert_eq "4" "$RUN_CODE" "tag add should fail for unknown commit"
   assert_contains "$RUN_STDERR" "Commit not found:" "tag add should report unknown commit"
 }
 
-case_089_tag_add_invalid_name() {
+case_090_tag_add_invalid_name() {
   setup_commit_without_tags
   run_omohi_capture tag add "$LAST_COMMIT_ID" ""
   assert_eq "3" "$RUN_CODE" "tag add should reject empty tag"
   assert_contains "$RUN_STDERR" "unexpected system error" "tag add invalid tag currently uses generic runtime message"
 }
 
-case_090_tag_rm_single() {
+case_091_tag_rm_single() {
   setup_commit_with_two_files_and_tags
   run_omohi_capture tag rm "$LAST_COMMIT_ID" alpha
   assert_eq "0" "$RUN_CODE" "tag rm should succeed"
@@ -1148,14 +1164,14 @@ case_090_tag_rm_single() {
   assert_contains "$RUN_STDOUT" "beta" "tag rm should list remaining tags"
 }
 
-case_091_tag_rm_multiple() {
+case_092_tag_rm_multiple() {
   setup_commit_with_two_files_and_tags
   run_omohi_capture tag rm "$LAST_COMMIT_ID" alpha beta
   assert_eq "0" "$RUN_CODE" "tag rm should succeed for multiple tags"
   assert_contains "$RUN_STDOUT" "Removed 2 tag(s) from commit $LAST_COMMIT_ID." "tag rm should report removed count"
 }
 
-case_092_tag_rm_no_tags() {
+case_093_tag_rm_no_tags() {
   setup_commit_without_tags
   run_omohi_capture tag rm "$LAST_COMMIT_ID" release
   assert_eq "0" "$RUN_CODE" "tag rm should succeed for tagless commit"
@@ -1163,7 +1179,7 @@ case_092_tag_rm_no_tags() {
   assert_contains "$RUN_STDOUT" "(none)" "tag rm should show empty result"
 }
 
-case_093_tag_rm_no_matching_tags() {
+case_094_tag_rm_no_matching_tags() {
   setup_commit_with_two_files_and_tags
   run_omohi_capture tag rm "$LAST_COMMIT_ID" release
   assert_eq "0" "$RUN_CODE" "tag rm should succeed for no-op removal"
@@ -1172,14 +1188,14 @@ case_093_tag_rm_no_matching_tags() {
   assert_contains "$RUN_STDOUT" "beta" "tag rm should still show beta tag"
 }
 
-case_094_tag_rm_unknown_commit() {
+case_095_tag_rm_unknown_commit() {
   setup_commit_without_tags
   run_omohi_capture tag rm 0000000000000000000000000000000000000000000000000000000000000000 release
   assert_eq "4" "$RUN_CODE" "tag rm should fail for unknown commit"
   assert_contains "$RUN_STDERR" "Commit not found:" "tag rm should report unknown commit"
 }
 
-case_095_tag_rm_invalid_name() {
+case_096_tag_rm_invalid_name() {
   local long_tag
   long_tag="$(make_long_tag)"
   setup_commit_without_tags
@@ -1305,19 +1321,20 @@ run_case "journal non-empty" case_079_journal_non_empty
 run_case "journal empty" case_080_journal_empty
 run_case "journal rejects extra args" case_081_journal_rejects_extra_args
 run_case "tag ls with tags" case_082_tag_ls_with_tags
-run_case "tag ls without tags" case_083_tag_ls_without_tags
-run_case "tag ls unknown commit" case_084_tag_ls_unknown_commit
-run_case "tag add single" case_085_tag_add_single
-run_case "tag add multiple" case_086_tag_add_multiple
-run_case "tag add existing only" case_087_tag_add_existing_only
-run_case "tag add unknown commit" case_088_tag_add_unknown_commit
-run_case "tag add invalid name" case_089_tag_add_invalid_name
-run_case "tag rm single" case_090_tag_rm_single
-run_case "tag rm multiple" case_091_tag_rm_multiple
-run_case "tag rm no tags" case_092_tag_rm_no_tags
-run_case "tag rm no matching tags" case_093_tag_rm_no_matching_tags
-run_case "tag rm unknown commit" case_094_tag_rm_unknown_commit
-run_case "tag rm invalid name" case_095_tag_rm_invalid_name
+run_case "tag field only" case_083_tag_field_only
+run_case "tag ls without tags" case_084_tag_ls_without_tags
+run_case "tag ls unknown commit" case_085_tag_ls_unknown_commit
+run_case "tag add single" case_086_tag_add_single
+run_case "tag add multiple" case_087_tag_add_multiple
+run_case "tag add existing only" case_088_tag_add_existing_only
+run_case "tag add unknown commit" case_089_tag_add_unknown_commit
+run_case "tag add invalid name" case_090_tag_add_invalid_name
+run_case "tag rm single" case_091_tag_rm_single
+run_case "tag rm multiple" case_092_tag_rm_multiple
+run_case "tag rm no tags" case_093_tag_rm_no_tags
+run_case "tag rm no matching tags" case_094_tag_rm_no_matching_tags
+run_case "tag rm unknown commit" case_095_tag_rm_unknown_commit
+run_case "tag rm invalid name" case_096_tag_rm_invalid_name
 run_case "help default" case_096_help_default
 run_case "help topic ignored" case_097_help_topic_ignored
 run_case "help short alias" case_098_help_short_alias

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,8 +17,8 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 | `find` | `find [--tag <tag>] [--empty|--no-empty] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...` | Search commits by optional tag, empty-commit, and local-time range filters. |
 | `show` | `show [--output <text|json>] [--field <commit_id|message|created_at|paths|tags>]... <commitId>` | Show one commit details payload. |
 | `journal` | `journal` | Show recent journal logs in reverse chronological order. |
-| `tag` | `tag` | List all known tag names. |
-| `tag ls` | `tag ls <commitId>` | List tags for one commit. |
+| `tag` | `tag [--field <tag>]...` | List all known tag names. |
+| `tag ls` | `tag ls [--field <tag>]... <commitId>` | List tags for one commit. |
 | `tag add` | `tag add <commitId> <tagNames...>` | Attach one or more tags to a commit. |
 | `tag rm` | `tag rm <commitId> <tagNames...>` | Remove one or more tags from a commit. |
 | `help` | `help` | Print command usages. |
@@ -237,30 +237,33 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 
 ### tag
 
-- Usage: `omohi tag`
+- Usage: `omohi tag [--field <tag>]...`
 - Summary: List all known tag names.
 - Positionals:
   - None
 - Options:
-  - None
+  - `--field` `<tag>` (optional, repeatable): Select one or more fields. Repeat to keep field order.
 - Examples:
   - `omohi tag`
+  - `omohi tag --field tag`
 - Notes:
   - Lists persisted tag names in ascending order.
+  - When `--field` is set, only the selected tag values are printed, one per line.
   - Use `tag ls <commitId>` to inspect tags attached to one commit.
 
 ### tag ls
 
-- Usage: `omohi tag ls <commitId>`
+- Usage: `omohi tag ls [--field <tag>]... <commitId>`
 - Summary: List tags for one commit.
 - Positionals:
   - `commitId` (required): 64-char commit ID.
 - Options:
-  - None
+  - `--field` `<tag>` (optional, repeatable): Select one or more fields. Repeat to keep field order.
 - Examples:
   - `omohi tag ls aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+  - `omohi tag ls --field tag aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
 - Notes:
-  - None
+  - When `--field` is set, only the selected tag values are printed, one per line.
 
 ### tag add
 

--- a/docs/man/omohi.1
+++ b/docs/man/omohi.1
@@ -462,17 +462,27 @@ List all known tag names.
 .TP
 .B Usage
 .nf
-omohi tag
+omohi tag [\-\-field <tag>]...
 .fi
+.TP
+.B Options
+.RS 4
+.B \-\-field <tag>
+optional, repeatable: Select one or more fields. Repeat to keep field order.
+.RE
 .TP
 .B Examples
 .nf
 omohi tag
+omohi tag \-\-field tag
 .fi
 .TP
 .B Notes
 .RS 4
 Lists persisted tag names in ascending order.
+.RE
+.RS 4
+When `\-\-field` is set, only the selected tag values are printed, one per line.
 .RE
 .RS 4
 Use `tag ls <commitId>` to inspect tags attached to one commit.
@@ -484,7 +494,7 @@ List tags for one commit.
 .TP
 .B Usage
 .nf
-omohi tag ls <commitId>
+omohi tag ls [\-\-field <tag>]... <commitId>
 .fi
 .TP
 .B Positionals
@@ -493,10 +503,22 @@ omohi tag ls <commitId>
 required: 64\-char commit ID.
 .RE
 .TP
+.B Options
+.RS 4
+.B \-\-field <tag>
+optional, repeatable: Select one or more fields. Repeat to keep field order.
+.RE
+.TP
 .B Examples
 .nf
 omohi tag ls aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+omohi tag ls \-\-field tag aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 .fi
+.TP
+.B Notes
+.RS 4
+When `\-\-field` is set, only the selected tag values are printed, one per line.
+.RE
 .SS tag add
 .TP
 .B Summary

--- a/src/app/cli/command/tag.zig
+++ b/src/app/cli/command/tag.zig
@@ -8,14 +8,12 @@ const tag_ops = @import("../../../ops/tag_ops.zig");
 
 // Runs the `tag` command and returns owned CLI output for the caller to free.
 pub fn run(allocator: std.mem.Allocator, args: parser_types.TagArgs) !command_types.CommandResult {
-    _ = args;
-
     var omohi = try environment.openOmohiDir(allocator, false);
     defer omohi.deinit(allocator);
 
     var tags = try tag_ops.listAll(allocator, omohi.dir);
     defer tag_ops.freeTagNameList(allocator, &tags);
 
-    const output = try presenter.tagNameListResult(allocator, &tags);
+    const output = try presenter.tagNameListResult(allocator, &tags, args.fields);
     return .{ .output = output, .to_stderr = false, .exit_code = exit_code.ok };
 }

--- a/src/app/cli/command/tag_ls.zig
+++ b/src/app/cli/command/tag_ls.zig
@@ -17,7 +17,7 @@ pub fn run(allocator: std.mem.Allocator, args: parser_types.TagLsArgs) !command_
     };
     defer tag_ops.freeTagList(allocator, &tags);
 
-    const output = try presenter.tagListResult(allocator, args.commit_id, &tags);
+    const output = try presenter.tagListResult(allocator, args.commit_id, &tags, args.fields);
     return .{ .output = output, .to_stderr = false, .exit_code = exit_code.ok };
 }
 

--- a/src/app/cli/command_catalog.zig
+++ b/src/app/cli/command_catalog.zig
@@ -259,26 +259,36 @@ pub const all = [_]CommandSpec{
     },
     .{
         .name = "tag",
-        .usage = "tag",
+        .usage = "tag [--field <tag>]...",
         .summary = "List all known tag names.",
         .positionals = &.{},
-        .options = &.{},
-        .examples = &.{"omohi tag"},
+        .options = &.{
+            .{ .long = "field", .short = null, .value_name = "tag", .required = false, .repeatable = true, .description = "Select one or more fields. Repeat to keep field order." },
+        },
+        .examples = &.{ "omohi tag", "omohi tag --field tag" },
         .notes = &.{
             "Lists persisted tag names in ascending order.",
+            "When `--field` is set, only the selected tag values are printed, one per line.",
             "Use `tag ls <commitId>` to inspect tags attached to one commit.",
         },
     },
     .{
         .name = "tag ls",
-        .usage = "tag ls <commitId>",
+        .usage = "tag ls [--field <tag>]... <commitId>",
         .summary = "List tags for one commit.",
         .positionals = &.{
             .{ .name = "commitId", .required = true, .repeatable = false, .description = "64-char commit ID." },
         },
-        .options = &.{},
-        .examples = &.{"omohi tag ls aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
-        .notes = &.{},
+        .options = &.{
+            .{ .long = "field", .short = null, .value_name = "tag", .required = false, .repeatable = true, .description = "Select one or more fields. Repeat to keep field order." },
+        },
+        .examples = &.{
+            "omohi tag ls aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "omohi tag ls --field tag aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+        .notes = &.{
+            "When `--field` is set, only the selected tag values are printed, one per line.",
+        },
     },
     .{
         .name = "tag add",
@@ -411,6 +421,8 @@ fn assertFieldValueSpecs() void {
     assertOptionValueSpecForCommand("tracklist", "field", parser_types.TracklistField);
     assertOptionValueSpecForCommand("find", "field", parser_types.FindField);
     assertOptionValueSpecForCommand("show", "field", parser_types.ShowField);
+    assertOptionValueSpecForCommand("tag", "field", parser_types.TagField);
+    assertOptionValueSpecForCommand("tag ls", "field", parser_types.TagField);
 }
 
 // Verifies that a command option's allowed values match an enum's tag names.
@@ -496,6 +508,8 @@ fn optionTakesValue(comptime command_name: []const u8, comptime option_long: []c
     if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "field")) return true;
     if (std.mem.eql(u8, command_name, "show") and std.mem.eql(u8, option_long, "output")) return true;
     if (std.mem.eql(u8, command_name, "show") and std.mem.eql(u8, option_long, "field")) return true;
+    if (std.mem.eql(u8, command_name, "tag") and std.mem.eql(u8, option_long, "field")) return true;
+    if (std.mem.eql(u8, command_name, "tag ls") and std.mem.eql(u8, option_long, "field")) return true;
     @compileError(std.fmt.comptimePrint(
         "missing parser option behavior mapping for command '{s}' option '--{s}'",
         .{ command_name, option_long },

--- a/src/app/cli/parser/parse.zig
+++ b/src/app/cli/parser/parse.zig
@@ -24,10 +24,11 @@ pub fn parseArgs(allocator: std.mem.Allocator, argv: []const []const u8) !types.
     }
 
     if (std.mem.eql(u8, argv[0], "tag")) {
-        if (argv.len == 1) return try parseNoArgsCommand(.tag, argv[1..]);
-        if (std.mem.eql(u8, argv[1], "ls")) return try parseTagLs(argv[2..]);
+        if (argv.len == 1) return try parseTag(argv[1..], allocator);
+        if (std.mem.eql(u8, argv[1], "ls")) return try parseTagLs(argv[2..], allocator);
         if (std.mem.eql(u8, argv[1], "add")) return try parseTagAdd(argv[2..]);
         if (std.mem.eql(u8, argv[1], "rm")) return try parseTagRm(argv[2..]);
+        if (std.mem.startsWith(u8, argv[1], "-")) return try parseTag(argv[1..], allocator);
         return error.InvalidCommand;
     }
 
@@ -284,10 +285,77 @@ fn parseJournal(args: []const []const u8) !types.ParsedRequest {
     return .{ .journal = .{} };
 }
 
-// Parses `tag ls <commitId>`.
-fn parseTagLs(args: []const []const u8) !types.ParsedRequest {
-    if (args.len != 1) return error.MissingArgument;
-    return .{ .tag_ls = .{ .commit_id = args[0] } };
+// Parses `tag` options for field selection.
+fn parseTag(args: []const []const u8, allocator: std.mem.Allocator) !types.ParsedRequest {
+    var fields = std.array_list.Managed(types.TagField).init(allocator);
+    errdefer fields.deinit();
+
+    var idx: usize = 0;
+    var stop_option = false;
+    while (idx < args.len) : (idx += 1) {
+        const token = args[idx];
+
+        if (!stop_option and scan.isDoubleDash(token)) {
+            stop_option = true;
+            continue;
+        }
+
+        if (!stop_option) {
+            if (scan.parseLongOption(token)) |opt| {
+                if (scan.equalsIgnoreAsciiCase(opt.key, "field")) {
+                    const value = try scan.optionValue(args, &idx, opt.value);
+                    try fields.append(try parseTagField(value));
+                    continue;
+                }
+
+                return error.UnknownOption;
+            }
+        }
+
+        return error.UnexpectedArgument;
+    }
+
+    return .{ .tag = .{
+        .fields = try fields.toOwnedSlice(),
+    } };
+}
+
+// Parses `tag ls <commitId>` plus field selection options.
+fn parseTagLs(args: []const []const u8, allocator: std.mem.Allocator) !types.ParsedRequest {
+    var fields = std.array_list.Managed(types.TagField).init(allocator);
+    errdefer fields.deinit();
+
+    var commit_id: ?[]const u8 = null;
+    var idx: usize = 0;
+    var stop_option = false;
+    while (idx < args.len) : (idx += 1) {
+        const token = args[idx];
+
+        if (!stop_option and scan.isDoubleDash(token)) {
+            stop_option = true;
+            continue;
+        }
+
+        if (!stop_option) {
+            if (scan.parseLongOption(token)) |opt| {
+                if (scan.equalsIgnoreAsciiCase(opt.key, "field")) {
+                    const value = try scan.optionValue(args, &idx, opt.value);
+                    try fields.append(try parseTagField(value));
+                    continue;
+                }
+
+                return error.UnknownOption;
+            }
+        }
+
+        if (commit_id != null) return error.UnexpectedArgument;
+        commit_id = token;
+    }
+
+    return .{ .tag_ls = .{
+        .commit_id = commit_id orelse return error.MissingArgument,
+        .fields = try fields.toOwnedSlice(),
+    } };
 }
 
 // Parses `tag add <commitId> <tagNames...>`.
@@ -590,6 +658,12 @@ fn parseShowField(value: []const u8) !types.ShowField {
     return error.InvalidArgument;
 }
 
+// Parses a `tag` field name into its enum form.
+fn parseTagField(value: []const u8) !types.TagField {
+    if (scan.equalsIgnoreAsciiCase(value, "tag")) return .tag;
+    return error.InvalidArgument;
+}
+
 test "parser preserves show unknown long option behavior" {
     const allocator = std.testing.allocator;
     const argv = [_][]const u8{ "show", "--bogus" };
@@ -609,7 +683,10 @@ test "parser resolves longest command match for tag subcommands" {
     defer types.deinitParsedRequest(allocator, &parsed);
 
     switch (parsed) {
-        .tag_ls => |args| try std.testing.expectEqualStrings("abc", args.commit_id),
+        .tag_ls => |args| {
+            try std.testing.expectEqualStrings("abc", args.commit_id);
+            try std.testing.expectEqual(@as(usize, 0), args.fields.len);
+        },
         else => return error.UnexpectedResult,
     }
 }
@@ -621,8 +698,41 @@ test "parser accepts bare tag command" {
     defer types.deinitParsedRequest(allocator, &parsed);
 
     switch (parsed) {
-        .tag => {},
+        .tag => |args| try std.testing.expectEqual(@as(usize, 0), args.fields.len),
         else => return error.UnexpectedResult,
+    }
+}
+
+test "parser accepts tag field selection" {
+    const allocator = std.testing.allocator;
+
+    {
+        const argv = [_][]const u8{ "tag", "--field", "tag" };
+        var parsed = try parseArgs(allocator, &argv);
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .tag => |args| {
+                try std.testing.expectEqual(@as(usize, 1), args.fields.len);
+                try std.testing.expectEqual(types.TagField.tag, args.fields[0]);
+            },
+            else => return error.UnexpectedResult,
+        }
+    }
+
+    {
+        const argv = [_][]const u8{ "tag", "ls", "abc", "--field=tag" };
+        var parsed = try parseArgs(allocator, &argv);
+        defer types.deinitParsedRequest(allocator, &parsed);
+
+        switch (parsed) {
+            .tag_ls => |args| {
+                try std.testing.expectEqualStrings("abc", args.commit_id);
+                try std.testing.expectEqual(@as(usize, 1), args.fields.len);
+                try std.testing.expectEqual(types.TagField.tag, args.fields[0]);
+            },
+            else => return error.UnexpectedResult,
+        }
     }
 }
 
@@ -1231,6 +1341,14 @@ test "parser rejects unknown reference fields" {
     }
     {
         const argv = [_][]const u8{ "show", "--field", "unknown", "abc" };
+        try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &argv));
+    }
+    {
+        const argv = [_][]const u8{ "tag", "--field", "unknown" };
+        try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &argv));
+    }
+    {
+        const argv = [_][]const u8{ "tag", "ls", "abc", "--field", "unknown" };
         try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &argv));
     }
 }

--- a/src/app/cli/parser/types.zig
+++ b/src/app/cli/parser/types.zig
@@ -28,6 +28,10 @@ pub const ShowField = enum {
     tags,
 };
 
+pub const TagField = enum {
+    tag,
+};
+
 pub const TrackArgs = struct {
     paths: []const []const u8,
 };
@@ -79,10 +83,13 @@ pub const ShowArgs = struct {
 
 pub const JournalArgs = struct {};
 
-pub const TagArgs = void;
+pub const TagArgs = struct {
+    fields: []const TagField,
+};
 
 pub const TagLsArgs = struct {
     commit_id: []const u8,
+    fields: []const TagField,
 };
 
 pub const TagAddArgs = struct {
@@ -131,6 +138,8 @@ pub fn deinitParsedRequest(allocator: std.mem.Allocator, parsed: *ParsedRequest)
         .tracklist => |args| allocator.free(args.fields),
         .find => |args| allocator.free(args.fields),
         .show => |args| allocator.free(args.fields),
+        .tag => |args| allocator.free(args.fields),
+        .tag_ls => |args| allocator.free(args.fields),
         else => {},
     }
 }

--- a/src/app/cli/presenter/output.zig
+++ b/src/app/cli/presenter/output.zig
@@ -648,7 +648,14 @@ fn renderShowJson(
 }
 
 // Renders tags for a commit as owned CLI output.
-pub fn tagListResult(allocator: std.mem.Allocator, commit_id: []const u8, tags: *const tag_ops.TagList) ![]u8 {
+pub fn tagListResult(
+    allocator: std.mem.Allocator,
+    commit_id: []const u8,
+    tags: *const tag_ops.TagList,
+    fields: []const parser_types.TagField,
+) ![]u8 {
+    if (fields.len != 0) return writeTagFieldLines(allocator, tags.items, fields);
+
     var out = std.array_list.Managed(u8).init(allocator);
     errdefer out.deinit();
     const writer = out.writer();
@@ -660,7 +667,13 @@ pub fn tagListResult(allocator: std.mem.Allocator, commit_id: []const u8, tags: 
 }
 
 // Renders the global tag-name list as owned CLI output.
-pub fn tagNameListResult(allocator: std.mem.Allocator, tags: *const tag_ops.TagNameList) ![]u8 {
+pub fn tagNameListResult(
+    allocator: std.mem.Allocator,
+    tags: *const tag_ops.TagNameList,
+    fields: []const parser_types.TagField,
+) ![]u8 {
+    if (fields.len != 0) return writeTagFieldLines(allocator, tags.items, fields);
+
     var out = std.array_list.Managed(u8).init(allocator);
     errdefer out.deinit();
     const writer = out.writer();
@@ -766,6 +779,26 @@ fn writeTagLines(writer: anytype, tags: []const []u8) !void {
     }
 }
 
+// Writes one line per tag for selected tag fields and emits nothing for empty lists.
+fn writeTagFieldLines(
+    allocator: std.mem.Allocator,
+    tags: []const []u8,
+    fields: []const parser_types.TagField,
+) ![]u8 {
+    if (!containsTagField(fields, .tag)) return allocator.alloc(u8, 0);
+
+    var out = std.array_list.Managed(u8).init(allocator);
+    errdefer out.deinit();
+    const writer = out.writer();
+
+    for (tags) |tag_name| {
+        try writer.writeAll(tag_name);
+        try writer.writeByte('\n');
+    }
+
+    return out.toOwnedSlice();
+}
+
 // Writes one selected text value with a leading space separator after the first column.
 fn writeSelectedValue(writer: anytype, first: *bool, value: []const u8) !void {
     if (!first.*) try writer.writeByte(' ');
@@ -812,6 +845,14 @@ fn containsFindField(fields: []const parser_types.FindField, needle: parser_type
 
 // Reports whether the given `show` field list contains the requested field.
 fn containsShowField(fields: []const parser_types.ShowField, needle: parser_types.ShowField) bool {
+    for (fields) |field| {
+        if (field == needle) return true;
+    }
+    return false;
+}
+
+// Reports whether the given `tag` field list contains the requested field.
+fn containsTagField(fields: []const parser_types.TagField, needle: parser_types.TagField) bool {
     for (fields) |field| {
         if (field == needle) return true;
     }
@@ -1863,7 +1904,7 @@ test "tagNameListResult renders count and one tag per line" {
     try tags.append(try std.testing.allocator.dupe(u8, "mobile"));
     try tags.append(try std.testing.allocator.dupe(u8, "release"));
 
-    const output = try tagNameListResult(std.testing.allocator, &tags);
+    const output = try tagNameListResult(std.testing.allocator, &tags, &.{});
     defer std.testing.allocator.free(output);
 
     try std.testing.expectEqualStrings(
@@ -1888,6 +1929,7 @@ test "tagListResult renders count and one tag per line" {
         std.testing.allocator,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         &tags,
+        &.{},
     );
     defer std.testing.allocator.free(output);
 
@@ -1927,6 +1969,7 @@ test "tagListResult renders none when no tags exist" {
         std.testing.allocator,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         &tags,
+        &.{},
     );
     defer std.testing.allocator.free(output);
 
@@ -1941,7 +1984,7 @@ test "tagNameListResult renders none when no tags exist" {
     var tags = tag_ops.TagNameList.init(std.testing.allocator);
     defer tags.deinit();
 
-    const output = try tagNameListResult(std.testing.allocator, &tags);
+    const output = try tagNameListResult(std.testing.allocator, &tags, &.{});
     defer std.testing.allocator.free(output);
 
     try std.testing.expectEqualStrings(
@@ -1949,6 +1992,71 @@ test "tagNameListResult renders none when no tags exist" {
             "(none)\n",
         output,
     );
+}
+
+test "tagNameListResult renders selected tag field only" {
+    var tags = tag_ops.TagNameList.init(std.testing.allocator);
+    defer {
+        for (tags.items) |tag_name| std.testing.allocator.free(tag_name);
+        tags.deinit();
+    }
+
+    try tags.append(try std.testing.allocator.dupe(u8, "mobile"));
+    try tags.append(try std.testing.allocator.dupe(u8, "release"));
+
+    const output = try tagNameListResult(std.testing.allocator, &tags, &.{.tag});
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expectEqualStrings(
+        "mobile\n" ++
+            "release\n",
+        output,
+    );
+}
+
+test "tagListResult renders selected tag field only" {
+    var tags = tag_ops.TagList.init(std.testing.allocator);
+    defer {
+        for (tags.items) |tag_name| std.testing.allocator.free(tag_name);
+        tags.deinit();
+    }
+
+    try tags.append(try std.testing.allocator.dupe(u8, "mobile"));
+    try tags.append(try std.testing.allocator.dupe(u8, "release"));
+
+    const output = try tagListResult(
+        std.testing.allocator,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        &tags,
+        &.{.tag},
+    );
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expectEqualStrings(
+        "mobile\n" ++
+            "release\n",
+        output,
+    );
+}
+
+test "tag field output emits empty output for empty lists" {
+    var global_tags = tag_ops.TagNameList.init(std.testing.allocator);
+    defer global_tags.deinit();
+    var commit_tags = tag_ops.TagList.init(std.testing.allocator);
+    defer commit_tags.deinit();
+
+    const global_output = try tagNameListResult(std.testing.allocator, &global_tags, &.{.tag});
+    defer std.testing.allocator.free(global_output);
+    try std.testing.expectEqualStrings("", global_output);
+
+    const commit_output = try tagListResult(
+        std.testing.allocator,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        &commit_tags,
+        &.{.tag},
+    );
+    defer std.testing.allocator.free(commit_output);
+    try std.testing.expectEqualStrings("", commit_output);
 }
 
 test "tagRmResult renders no-matching branch" {

--- a/src/ops/completion_ops.zig
+++ b/src/ops/completion_ops.zig
@@ -16,10 +16,12 @@ const untrack_options = [_][]const u8{"--missing"};
 const tracklist_options = [_][]const u8{ "--output", "--field" };
 const find_options = [_][]const u8{ "-t", "--tag", "--empty", "--no-empty", "-s", "--since", "-u", "--until", "--limit", "--output", "--field" };
 const show_options = [_][]const u8{ "--output", "--field" };
+const tag_options = [_][]const u8{"--field"};
 const output_values = [_][]const u8{ "text", "json" };
 const tracklist_field_values = [_][]const u8{ "id", "path" };
 const find_field_values = [_][]const u8{ "commit_id", "message", "created_at" };
 const show_field_values = [_][]const u8{ "commit_id", "message", "created_at", "paths", "tags" };
+const tag_field_values = [_][]const u8{"tag"};
 const help_topics = [_][]const u8{ "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "tag", "help" };
 
 // Reports whether completion at the current cursor position needs store-backed data.
@@ -174,13 +176,33 @@ fn completeTagCommand(
     index: usize,
     current: []const u8,
 ) !void {
+    if (expectsValue(words, index, "--field", "")) {
+        try appendFilteredStatic(allocator, out, &tag_field_values, current);
+        return;
+    }
+
     if (index == 2) {
         try appendFilteredStatic(allocator, out, &tag_commands, current);
+        try appendFilteredStatic(allocator, out, &tag_options, current);
         return;
     }
     if (words.len < 3) return;
 
     const subcommand = words[2];
+    if (std.mem.startsWith(u8, subcommand, "--")) {
+        try appendFilteredStatic(allocator, out, &tag_options, current);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "ls")) {
+        if (index == 3 and isOptionLike(current)) {
+            try appendFilteredStatic(allocator, out, &tag_options, current);
+            return;
+        }
+        if (index > 3 and isOptionLike(current)) {
+            try appendFilteredStatic(allocator, out, &tag_options, current);
+            return;
+        }
+    }
     if (index == 3) {
         if ((std.mem.eql(u8, subcommand, "ls") or std.mem.eql(u8, subcommand, "add") or std.mem.eql(u8, subcommand, "rm")) and maybe_omohi_dir != null) {
             var ids = try loadCommitIds(allocator, maybe_omohi_dir.?);
@@ -427,10 +449,11 @@ test "complete returns tag subcommands for bare tag command" {
     var list = try complete(allocator, null, &words, 2);
     defer freeCandidateList(allocator, &list);
 
-    try std.testing.expectEqual(@as(usize, 3), list.items.len);
+    try std.testing.expectEqual(@as(usize, 4), list.items.len);
     try std.testing.expectEqualStrings("ls", list.items[0]);
     try std.testing.expectEqualStrings("add", list.items[1]);
     try std.testing.expectEqualStrings("rm", list.items[2]);
+    try std.testing.expectEqualStrings("--field", list.items[3]);
 }
 
 test "complete returns rm options and staged paths" {
@@ -566,6 +589,30 @@ test "complete returns reference output and field candidates" {
         defer freeCandidateList(allocator, &list);
         try std.testing.expectEqual(@as(usize, 1), list.items.len);
         try std.testing.expectEqualStrings("json", list.items[0]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "tag", "--f" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+        try std.testing.expectEqual(@as(usize, 1), list.items.len);
+        try std.testing.expectEqualStrings("--field", list.items[0]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "tag", "--field", "t" };
+        var list = try complete(allocator, null, &words, 3);
+        defer freeCandidateList(allocator, &list);
+        try std.testing.expectEqual(@as(usize, 1), list.items.len);
+        try std.testing.expectEqualStrings("tag", list.items[0]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "tag", "ls", "--field", "t" };
+        var list = try complete(allocator, null, &words, 4);
+        defer freeCandidateList(allocator, &list);
+        try std.testing.expectEqual(@as(usize, 1), list.items.len);
+        try std.testing.expectEqualStrings("tag", list.items[0]);
     }
 }
 


### PR DESCRIPTION
## Summary

Added a `--field` option to filtering by specified field for `omohi tag` and `omohi tag ls` commands.

## Related Issue

## Testing

- [x] Tests run
- [ ] Not run

List the tests or checks you ran.
If you did not run them, explain why.

## Docs

- [x] Docs updated
- [ ] N/A

List updated docs if applicable.

## Checklist

- [x] The change is small and focused.
- [x] I completed the Testing section.
- [x] I completed the Docs section.
- [x] I called out any breaking change in this PR description.
