### PR TITLE
Add backup command

### DIFF
--- a/.github/scripts/omohi_completion.sh
+++ b/.github/scripts/omohi_completion.sh
@@ -38,7 +38,7 @@ shift
 
 case "$*" in
   "omohi " )
-    printf '%s\n' track untrack add rm commit status tracklist version find show tag help -h --help -v --version
+    printf '%s\n' track untrack add rm commit status tracklist version find show journal backup tag help -h --help -v --version
     ;;
   "omohi tag " )
     printf '%s\n' ls add rm --field
@@ -94,6 +94,12 @@ case "$*" in
   "omohi tracklist --field " )
     printf '%s\n' id path
     ;;
+  "omohi backup " )
+    printf '%s\n' --max-size
+    ;;
+  "omohi backup --" )
+    printf '%s\n' --max-size
+    ;;
   "omohi untrack " )
     printf '%s\n' 11111111111111111111111111111111 22222222222222222222222222222222
     ;;
@@ -135,7 +141,7 @@ assert_reply() {
   fi
 }
 
-assert_reply "track untrack add rm commit status tracklist version find show tag help -h --help -v --version" omohi ""
+assert_reply "track untrack add rm commit status tracklist version find show journal backup tag help -h --help -v --version" omohi ""
 assert_reply "ls add rm --field" omohi tag ""
 assert_reply "tag" omohi tag --field ""
 assert_reply "tag" omohi tag ls --field ""
@@ -153,6 +159,8 @@ assert_reply "--output" omohi tracklist --o
 assert_reply "text json" omohi tracklist --output ""
 assert_reply "id path" omohi tracklist --field ""
 assert_reply "" omohi status ""
+assert_reply "--max-size" omohi backup --
+assert_reply "" omohi backup --max-size ""
 assert_reply "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" omohi show ""
 assert_reply "" omohi commit --message ""
 assert_reply "11111111111111111111111111111111 22222222222222222222222222222222" omohi untrack ""

--- a/.github/scripts/omohi_e2e_matrix.sh
+++ b/.github/scripts/omohi_e2e_matrix.sh
@@ -1075,6 +1075,49 @@ case_081_journal_rejects_extra_args() {
   assert_contains "$RUN_STDERR" "Unexpected argument." "journal should report usage error"
 }
 
+case_081_backup_full_archive() {
+  local archive listing
+  setup_commit_without_tags
+  printf 'stale lock\n' > "$HOME_DIR/.omohi/LOCK"
+  mkdir -p "$HOME_DIR/.omohi/tracked/.trash"
+  printf 'deleted\n' > "$HOME_DIR/.omohi/tracked/.trash/deleted"
+  rm -f "$HOME_DIR/.omohi/LOCK"
+
+  archive="$WORK_DIR/backup.tar.gz"
+  run_omohi_capture backup "$archive"
+  assert_eq "0" "$RUN_CODE" "backup should succeed"
+  assert_contains "$RUN_STDOUT" "Backed up ~/.omohi to $archive" "backup should report target"
+  assert_file_exists "$archive" "backup archive should exist"
+
+  listing="$(tar -tzf "$archive")"
+  assert_contains "$listing" ".omohi/VERSION" "backup should include VERSION"
+  assert_contains "$listing" ".omohi/tracked/" "backup should include tracked data"
+  assert_not_contains "$listing" "LOCK" "backup should exclude LOCK"
+  assert_not_contains "$listing" ".trash" "backup should exclude trash data"
+}
+
+case_081_backup_rejects_existing_target() {
+  local archive
+  setup_commit_without_tags
+  archive="$WORK_DIR/existing.tar.gz"
+  printf 'existing\n' > "$archive"
+
+  run_omohi_capture backup "$archive"
+  assert_eq "4" "$RUN_CODE" "backup should reject existing target"
+  assert_contains "$RUN_STDERR" "Backup target already exists." "backup should explain existing target"
+}
+
+case_081_backup_rejects_small_max_size() {
+  local archive
+  setup_commit_without_tags
+  archive="$WORK_DIR/small.tar.gz"
+
+  run_omohi_capture backup --max-size 1 "$archive"
+  assert_eq "4" "$RUN_CODE" "backup should reject too-small max size"
+  assert_contains "$RUN_STDERR" "Backup is too large." "backup should explain size limit"
+  assert_file_missing "$archive" "backup should not leave archive when size guard fails"
+}
+
 case_082_tag_ls_with_tags() {
   setup_commit_with_two_files_and_tags
   run_omohi_capture tag ls "$LAST_COMMIT_ID"
@@ -1320,6 +1363,9 @@ run_case "show unknown commit" case_078_show_unknown_commit
 run_case "journal non-empty" case_079_journal_non_empty
 run_case "journal empty" case_080_journal_empty
 run_case "journal rejects extra args" case_081_journal_rejects_extra_args
+run_case "backup full archive" case_081_backup_full_archive
+run_case "backup rejects existing target" case_081_backup_rejects_existing_target
+run_case "backup rejects small max size" case_081_backup_rejects_small_max_size
 run_case "tag ls with tags" case_082_tag_ls_with_tags
 run_case "tag field only" case_083_tag_field_only
 run_case "tag ls without tags" case_084_tag_ls_without_tags

--- a/completions/omohi.bash
+++ b/completions/omohi.bash
@@ -8,7 +8,7 @@ _omohi_complete() {
   fi
   cword=${COMP_CWORD}
 
-  local top_level_commands="track untrack add rm commit status tracklist version find show journal tag help"
+  local top_level_commands="track untrack add rm commit status tracklist version find show journal backup tag help"
   local top_level_aliases="-h --help -v --version"
   local completion_command="${OMOHI_COMPLETION_COMMAND:-omohi}"
 
@@ -57,6 +57,19 @@ _omohi_complete() {
       return 0
       ;;
     status|version|journal)
+      return 0
+      ;;
+    backup)
+      if [[ "${prev}" == "--max-size" ]]; then
+        _omohi_collect_candidates
+        return 0
+      fi
+      if [[ -z "${cur}" || "${cur}" == -* ]]; then
+        _omohi_collect_candidates
+        return 0
+      fi
+      compopt -o filenames 2>/dev/null || true
+      COMPREPLY=( $(compgen -f -- "${cur}") )
       return 0
       ;;
     rm)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,7 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 | `find` | `find [--tag <tag>] [--empty|--no-empty] [--since <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--until <YYYY-MM-DD|YYYY-MM-DDTHH:MM:SS>] [--limit <1-500>] [--output <text|json>] [--field <commit_id|message|created_at>]...` | Search commits by optional tag, empty-commit, and local-time range filters. |
 | `show` | `show [--output <text|json>] [--field <commit_id|message|created_at|paths|tags>]... <commitId>` | Show one commit details payload. |
 | `journal` | `journal` | Show recent journal logs in reverse chronological order. |
+| `backup` | `backup [--max-size <bytes>] <archivePath>` | Create a full tar.gz backup archive of ~/.omohi. |
 | `tag` | `tag [--field <tag>]...` | List all known tag names. |
 | `tag ls` | `tag ls [--field <tag>]... <commitId>` | List tags for one commit. |
 | `tag add` | `tag add <commitId> <tagNames...>` | Attach one or more tags to a commit. |
@@ -234,6 +235,23 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
   - Shows the latest 500 successful mutating command records.
   - Displays timestamps in the local timezone.
   - TTY output is paged with less when available.
+
+### backup
+
+- Usage: `omohi backup [--max-size <bytes>] <archivePath>`
+- Summary: Create a full tar.gz backup archive of ~/.omohi.
+- Positionals:
+  - `archivePath` (required): Path to the backup archive to create.
+- Options:
+  - `--max-size` `<bytes>` (optional): Reject the backup if the estimated archive size exceeds this byte count. Defaults to 1073741824.
+- Examples:
+  - `omohi backup ~/omohi-backup.tar.gz`
+  - `omohi backup --max-size 2147483648 ~/omohi-backup.tar.gz`
+- Notes:
+  - The archive is written atomically through a temporary file beside the target path.
+  - The target archive must not already exist and must be outside ~/.omohi.
+  - `LOCK` and `.trash` directories are excluded from the archive.
+  - Backups are always full backups in this version.
 
 ### tag
 

--- a/docs/man/omohi.1
+++ b/docs/man/omohi.1
@@ -455,6 +455,47 @@ Displays timestamps in the local timezone.
 .RS 4
 TTY output is paged with less when available.
 .RE
+.SS backup
+.TP
+.B Summary
+Create a full tar.gz backup archive of ~/.omohi.
+.TP
+.B Usage
+.nf
+omohi backup [\-\-max\-size <bytes>] <archivePath>
+.fi
+.TP
+.B Positionals
+.RS 4
+.B archivePath
+required: Path to the backup archive to create.
+.RE
+.TP
+.B Options
+.RS 4
+.B \-\-max\-size <bytes>
+optional: Reject the backup if the estimated archive size exceeds this byte count. Defaults to 1073741824.
+.RE
+.TP
+.B Examples
+.nf
+omohi backup ~/omohi\-backup.tar.gz
+omohi backup \-\-max\-size 2147483648 ~/omohi\-backup.tar.gz
+.fi
+.TP
+.B Notes
+.RS 4
+The archive is written atomically through a temporary file beside the target path.
+.RE
+.RS 4
+The target archive must not already exist and must be outside ~/.omohi.
+.RE
+.RS 4
+`LOCK` and `.trash` directories are excluded from the archive.
+.RE
+.RS 4
+Backups are always full backups in this version.
+.RE
 .SS tag
 .TP
 .B Summary

--- a/src/app/cli/command/backup.zig
+++ b/src/app/cli/command/backup.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const parser_types = @import("../parser/types.zig");
+const command_types = @import("../runtime/types.zig");
+const environment = @import("../environment.zig");
+const path_resolver = @import("../path_resolver.zig");
+const presenter = @import("../presenter/output.zig");
+const exit_code = @import("../error/exit_code.zig");
+const backup_ops = @import("../../../ops/backup_ops.zig");
+
+// Runs the `backup` command and returns owned CLI output for the caller to free.
+pub fn run(allocator: std.mem.Allocator, args: parser_types.BackupArgs) !command_types.CommandResult {
+    var omohi = try environment.openOmohiDir(allocator, false);
+    defer omohi.deinit(allocator);
+
+    const archive_path = try path_resolver.resolveAbsolutePath(allocator, args.archive_path);
+    defer allocator.free(archive_path);
+
+    const result = try backup_ops.backup(
+        allocator,
+        omohi.dir,
+        omohi.path,
+        archive_path,
+        args.max_size,
+    );
+
+    const output = try presenter.backupResult(allocator, archive_path, result);
+    return .{ .output = output, .to_stderr = false, .exit_code = exit_code.ok };
+}

--- a/src/app/cli/command_catalog.zig
+++ b/src/app/cli/command_catalog.zig
@@ -41,6 +41,7 @@ pub const public_command_tags = [_]ParsedRequestTag{
     .find,
     .show,
     .journal,
+    .backup,
     .tag,
     .tag_ls,
     .tag_add,
@@ -255,6 +256,27 @@ pub const all = [_]CommandSpec{
             "Shows the latest 500 successful mutating command records.",
             "Displays timestamps in the local timezone.",
             "TTY output is paged with less when available.",
+        },
+    },
+    .{
+        .name = "backup",
+        .usage = "backup [--max-size <bytes>] <archivePath>",
+        .summary = "Create a full tar.gz backup archive of ~/.omohi.",
+        .positionals = &.{
+            .{ .name = "archivePath", .required = true, .repeatable = false, .description = "Path to the backup archive to create." },
+        },
+        .options = &.{
+            .{ .long = "max-size", .short = null, .value_name = "bytes", .required = false, .repeatable = false, .description = "Reject the backup if the estimated archive size exceeds this byte count. Defaults to 1073741824." },
+        },
+        .examples = &.{
+            "omohi backup ~/omohi-backup.tar.gz",
+            "omohi backup --max-size 2147483648 ~/omohi-backup.tar.gz",
+        },
+        .notes = &.{
+            "The archive is written atomically through a temporary file beside the target path.",
+            "The target archive must not already exist and must be outside ~/.omohi.",
+            "`LOCK` and `.trash` directories are excluded from the archive.",
+            "Backups are always full backups in this version.",
         },
     },
     .{
@@ -508,6 +530,7 @@ fn optionTakesValue(comptime command_name: []const u8, comptime option_long: []c
     if (std.mem.eql(u8, command_name, "find") and std.mem.eql(u8, option_long, "field")) return true;
     if (std.mem.eql(u8, command_name, "show") and std.mem.eql(u8, option_long, "output")) return true;
     if (std.mem.eql(u8, command_name, "show") and std.mem.eql(u8, option_long, "field")) return true;
+    if (std.mem.eql(u8, command_name, "backup") and std.mem.eql(u8, option_long, "max-size")) return true;
     if (std.mem.eql(u8, command_name, "tag") and std.mem.eql(u8, option_long, "field")) return true;
     if (std.mem.eql(u8, command_name, "tag ls") and std.mem.eql(u8, option_long, "field")) return true;
     @compileError(std.fmt.comptimePrint(

--- a/src/app/cli/error/error_map.zig
+++ b/src/app/cli/error/error_map.zig
@@ -15,7 +15,11 @@ pub fn exitCodeFor(err: anyerror) u8 {
         err == error.LockAlreadyAcquired or
         err == error.CommitNotFound or
         err == error.OmohiNotInitialized or
-        err == error.FileTooLarge)
+        err == error.FileTooLarge or
+        err == error.BackupTooLarge or
+        err == error.BackupTargetExists or
+        err == error.BackupTargetInsideStore or
+        err == error.UnsupportedBackupEntry)
     {
         return exit_code.use_case_error;
     }

--- a/src/app/cli/error/error_message.zig
+++ b/src/app/cli/error/error_message.zig
@@ -33,6 +33,10 @@ pub fn forRuntimeError(err: anyerror) []const u8 {
         error.AlreadyTracked => "The file is already tracked.",
         error.InvalidTrackedTarget => "Track target must be a file path or a directory expanded by the CLI.",
         error.FileTooLarge => "File is too large to stage.",
+        error.BackupTooLarge => "Backup is too large. Use --max-size to raise the limit or reduce stored data.",
+        error.BackupTargetExists => "Backup target already exists. Choose a new archive path.",
+        error.BackupTargetInsideStore => "Backup target must be outside ~/.omohi.",
+        error.UnsupportedBackupEntry => "Store contains an unsupported entry type for backup.",
         else => "Operation failed due to an unexpected system error.",
     };
 }

--- a/src/app/cli/parser/parse.zig
+++ b/src/app/cli/parser/parse.zig
@@ -43,6 +43,7 @@ pub fn parseArgs(allocator: std.mem.Allocator, argv: []const []const u8) !types.
     if (std.mem.eql(u8, argv[0], "find")) return try parseFind(allocator, argv[1..]);
     if (std.mem.eql(u8, argv[0], "show")) return try parseShow(allocator, argv[1..]);
     if (std.mem.eql(u8, argv[0], "journal")) return try parseJournal(argv[1..]);
+    if (std.mem.eql(u8, argv[0], "backup")) return try parseBackup(argv[1..]);
 
     return error.InvalidCommand;
 }
@@ -283,6 +284,43 @@ fn parseRm(args: []const []const u8) !types.ParsedRequest {
 fn parseJournal(args: []const []const u8) !types.ParsedRequest {
     if (args.len != 0) return error.UnexpectedArgument;
     return .{ .journal = .{} };
+}
+
+// Parses `backup <archivePath>` plus backup size guard options.
+fn parseBackup(args: []const []const u8) !types.ParsedRequest {
+    var max_size: u64 = 1024 * 1024 * 1024;
+    var archive_path: ?[]const u8 = null;
+    var idx: usize = 0;
+    var stop_option = false;
+    while (idx < args.len) : (idx += 1) {
+        const token = args[idx];
+
+        if (!stop_option and scan.isDoubleDash(token)) {
+            stop_option = true;
+            continue;
+        }
+
+        if (!stop_option) {
+            if (scan.parseLongOption(token)) |opt| {
+                if (scan.equalsIgnoreAsciiCase(opt.key, "max-size")) {
+                    const value = try scan.optionValue(args, &idx, opt.value);
+                    max_size = std.fmt.parseInt(u64, value, 10) catch return error.InvalidArgument;
+                    if (max_size == 0) return error.InvalidArgument;
+                    continue;
+                }
+
+                return error.UnknownOption;
+            }
+        }
+
+        if (archive_path != null) return error.UnexpectedArgument;
+        archive_path = token;
+    }
+
+    return .{ .backup = .{
+        .archive_path = archive_path orelse return error.MissingArgument,
+        .max_size = max_size,
+    } };
 }
 
 // Parses `tag` options for field selection.
@@ -1215,6 +1253,30 @@ test "parser accepts tracklist output and repeated fields" {
         },
         else => return error.UnexpectedResult,
     }
+}
+
+test "parser accepts backup archive path and max size" {
+    const allocator = std.testing.allocator;
+    const argv = [_][]const u8{ "backup", "--max-size=2048", "backup.tar.gz" };
+    var parsed = try parseArgs(allocator, &argv);
+    defer types.deinitParsedRequest(allocator, &parsed);
+
+    switch (parsed) {
+        .backup => |args| {
+            try std.testing.expectEqualStrings("backup.tar.gz", args.archive_path);
+            try std.testing.expectEqual(@as(u64, 2048), args.max_size);
+        },
+        else => return error.UnexpectedResult,
+    }
+}
+
+test "parser rejects invalid backup inputs" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.MissingArgument, parseArgs(allocator, &.{"backup"}));
+    try std.testing.expectError(error.MissingValue, parseArgs(allocator, &.{ "backup", "--max-size" }));
+    try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "backup", "--max-size", "0", "backup.tar.gz" }));
+    try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "backup", "--max-size", "abc", "backup.tar.gz" }));
+    try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "backup", "a.tar.gz", "b.tar.gz" }));
 }
 
 test "parser accepts find output and repeated fields" {

--- a/src/app/cli/parser/types.zig
+++ b/src/app/cli/parser/types.zig
@@ -83,6 +83,11 @@ pub const ShowArgs = struct {
 
 pub const JournalArgs = struct {};
 
+pub const BackupArgs = struct {
+    archive_path: []const u8,
+    max_size: u64,
+};
+
 pub const TagArgs = struct {
     fields: []const TagField,
 };
@@ -123,6 +128,7 @@ pub const ParsedRequest = union(enum) {
     find: FindArgs,
     show: ShowArgs,
     journal: JournalArgs,
+    backup: BackupArgs,
     tag: TagArgs,
     tag_ls: TagLsArgs,
     tag_add: TagAddArgs,

--- a/src/app/cli/presenter/output.zig
+++ b/src/app/cli/presenter/output.zig
@@ -10,6 +10,7 @@ const find_ops = @import("../../../ops/find_ops.zig");
 const show_ops = @import("../../../ops/show_ops.zig");
 const tag_ops = @import("../../../ops/tag_ops.zig");
 const journal_ops = @import("../../../ops/journal_ops.zig");
+const backup_ops = @import("../../../ops/backup_ops.zig");
 
 pub const TagRemoveOutcome = enum {
     no_tags,
@@ -242,6 +243,19 @@ pub fn rmMultiResult(allocator: std.mem.Allocator, outcome: *const rm_ops.RmOutc
 // Renders the created commit id as owned CLI output.
 pub fn commitResult(allocator: std.mem.Allocator, commit_id: [64]u8) ![]u8 {
     return std.fmt.allocPrint(allocator, "Committed {s}.\n", .{&commit_id});
+}
+
+// Renders backup completion as owned CLI output.
+pub fn backupResult(
+    allocator: std.mem.Allocator,
+    archive_path: []const u8,
+    result: backup_ops.BackupResult,
+) ![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "Backed up ~/.omohi to {s} ({d} bytes).\n",
+        .{ archive_path, result.archive_size },
+    );
 }
 
 // Renders journal entries as owned CLI output.

--- a/src/app/cli/runtime/dispatch.zig
+++ b/src/app/cli/runtime/dispatch.zig
@@ -12,6 +12,7 @@ const version = @import("../command/version.zig");
 const find = @import("../command/find.zig");
 const show = @import("../command/show.zig");
 const journal = @import("../command/journal.zig");
+const backup = @import("../command/backup.zig");
 const tag = @import("../command/tag.zig");
 const tag_ls = @import("../command/tag_ls.zig");
 const tag_add = @import("../command/tag_add.zig");
@@ -33,6 +34,7 @@ pub fn dispatch(allocator: std.mem.Allocator, parsed: parser_types.ParsedRequest
         .find => |args| try find.run(allocator, args),
         .show => |args| try show.run(allocator, args),
         .journal => |args| try journal.run(allocator, args),
+        .backup => |args| try backup.run(allocator, args),
         .tag => |args| try tag.run(allocator, args),
         .tag_ls => |args| try tag_ls.run(allocator, args),
         .tag_add => |args| try tag_add.run(allocator, args),

--- a/src/app/cli/runtime/journal_adapter.zig
+++ b/src/app/cli/runtime/journal_adapter.zig
@@ -42,6 +42,7 @@ pub fn fromParsedRequest(
             .tagNames = args.tag_names,
         }),
         .journal => null,
+        .backup => null,
         .complete => null,
         else => null,
     };

--- a/src/ops/backup_ops.zig
+++ b/src/ops/backup_ops.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+const store_api = @import("../store/api.zig");
+
+/// Default archive size limit for the backup command.
+pub const default_max_size: u64 = 1024 * 1024 * 1024;
+
+/// Describes a completed backup archive.
+pub const BackupResult = store_api.BackupResult;
+
+/// Creates a full backup archive for the current store.
+pub fn backup(
+    allocator: std.mem.Allocator,
+    omohi_dir: std.fs.Dir,
+    store_path: []const u8,
+    archive_path: []const u8,
+    max_size: u64,
+) !BackupResult {
+    return store_api.backupStore(allocator, omohi_dir, store_path, archive_path, max_size);
+}
+
+test "backup delegates to store and creates an archive" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try omohi_dir.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+
+    const store_path = try tmp.dir.realpathAlloc(allocator, ".omohi");
+    defer allocator.free(store_path);
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ tmp_path, "backup.tar.gz" });
+    defer allocator.free(archive_path);
+
+    const result = try backup(allocator, omohi_dir, store_path, archive_path, default_max_size);
+    try std.testing.expect(result.archive_size > 0);
+    try std.testing.expectError(error.FileNotFound, omohi_dir.openFile("LOCK", .{}));
+}

--- a/src/ops/completion_ops.zig
+++ b/src/ops/completion_ops.zig
@@ -5,7 +5,7 @@ const store_api = @import("../store/api.zig");
 pub const CandidateList = std.array_list.Managed([]u8);
 
 const top_level_commands = [_][]const u8{
-    "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "tag", "help",
+    "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "backup", "tag", "help",
 };
 const top_level_aliases = [_][]const u8{ "-h", "--help", "-v", "--version" };
 const tag_commands = [_][]const u8{ "ls", "add", "rm" };
@@ -16,13 +16,14 @@ const untrack_options = [_][]const u8{"--missing"};
 const tracklist_options = [_][]const u8{ "--output", "--field" };
 const find_options = [_][]const u8{ "-t", "--tag", "--empty", "--no-empty", "-s", "--since", "-u", "--until", "--limit", "--output", "--field" };
 const show_options = [_][]const u8{ "--output", "--field" };
+const backup_options = [_][]const u8{"--max-size"};
 const tag_options = [_][]const u8{"--field"};
 const output_values = [_][]const u8{ "text", "json" };
 const tracklist_field_values = [_][]const u8{ "id", "path" };
 const find_field_values = [_][]const u8{ "commit_id", "message", "created_at" };
 const show_field_values = [_][]const u8{ "commit_id", "message", "created_at", "paths", "tags" };
 const tag_field_values = [_][]const u8{"tag"};
-const help_topics = [_][]const u8{ "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "tag", "help" };
+const help_topics = [_][]const u8{ "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "backup", "tag", "help" };
 
 // Reports whether completion at the current cursor position needs store-backed data.
 pub fn requiresStore(words: []const []const u8, index: usize) bool {
@@ -145,6 +146,11 @@ pub fn complete(
     }
     if (std.mem.eql(u8, command, "show")) {
         try appendFilteredStatic(allocator, &out, &show_options, current);
+        return out;
+    }
+    if (std.mem.eql(u8, command, "backup")) {
+        if (expectsValue(words, index, "--max-size", "")) return out;
+        try appendFilteredStatic(allocator, &out, &backup_options, current);
         return out;
     }
     if (std.mem.eql(u8, command, "rm") and index == 2) {
@@ -538,6 +544,27 @@ test "complete returns no candidates for journal arguments" {
     defer freeCandidateList(allocator, &list);
 
     try std.testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "complete returns backup options" {
+    const allocator = std.testing.allocator;
+
+    {
+        const words = [_][]const u8{ "omohi", "backup", "--" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+
+        try std.testing.expectEqual(@as(usize, 1), list.items.len);
+        try std.testing.expectEqualStrings("--max-size", list.items[0]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "backup", "--max-size", "" };
+        var list = try complete(allocator, null, &words, 3);
+        defer freeCandidateList(allocator, &list);
+
+        try std.testing.expectEqual(@as(usize, 0), list.items.len);
+    }
 }
 
 test "complete returns reference output and field candidates" {

--- a/src/store/api.zig
+++ b/src/store/api.zig
@@ -18,6 +18,7 @@ const local_head = @import("./local/head.zig");
 const local_journal = @import("./local/journal.zig");
 const local_directory_tree_files = @import("./local/directory_tree_files.zig");
 const local_version = @import("./local/version.zig");
+const local_backup = @import("./local/backup.zig");
 const version_guard = @import("./storage/version_guard.zig");
 const ContentEntry = @import("./object/content_entry.zig").ContentEntry;
 const hash = @import("./object/hash.zig");
@@ -120,6 +121,9 @@ pub const JournalEntry = local_journal.JournalEntry;
 /// Owns journal entries returned by `journal`.
 pub const JournalEntryList = local_journal.JournalEntryList;
 
+/// Describes a completed backup archive.
+pub const BackupResult = local_backup.BackupResult;
+
 /// Carries commit metadata, entries, and tags for `show`.
 pub const CommitDetails = struct {
     commit_id: constrained_types.CommitId,
@@ -188,6 +192,29 @@ pub fn appendJournal(
         .local_ts = local_ts,
         .command_type = command_type,
         .payload_json = payload_json,
+    });
+}
+
+/// Writes a full backup archive for the opened store directory.
+/// Memory: borrowed path inputs, temporary allocations use allocator
+/// Lifetime: returned result is independent of allocator
+/// Errors: version, lock, validation, size limit, and filesystem/archive write failures
+/// Caller responsibilities: pass absolute normalized store and archive paths
+pub fn backupStore(
+    allocator: std.mem.Allocator,
+    omohi_dir: std.fs.Dir,
+    store_path: []const u8,
+    archive_path: []const u8,
+    max_size: u64,
+) !BackupResult {
+    try ensureStoreVersion(allocator, omohi_dir);
+    try lock.acquireLock(omohi_dir);
+    defer lock.releaseLock(omohi_dir);
+
+    return local_backup.writeBackup(allocator, omohi_dir, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .max_size = max_size,
     });
 }
 

--- a/src/store/local/backup.zig
+++ b/src/store/local/backup.zig
@@ -1,0 +1,370 @@
+const std = @import("std");
+
+const gzip_store = @import("../storage/gzip_store.zig");
+
+const default_backup_root = ".omohi";
+const gzip_header_size = 10;
+const gzip_footer_size = 8;
+const gzip_block_payload_size = 32 * 1024;
+const tar_block_size = 512;
+
+/// Carries normalized paths and the archive size guard for backup creation.
+pub const BackupOptions = struct {
+    store_path: []const u8,
+    archive_path: []const u8,
+    max_size: u64,
+};
+
+/// Reports the completed archive size and number of archived store entries.
+pub const BackupResult = struct {
+    archive_size: u64,
+    entry_count: usize,
+};
+
+const BackupEntry = struct {
+    path: []u8,
+    kind: Kind,
+    size: u64,
+    mtime: i128,
+
+    const Kind = enum {
+        directory,
+        file,
+    };
+};
+
+const BackupEntryList = std.array_list.Managed(BackupEntry);
+
+/// Writes a gzip-compressed tar backup of the opened store directory.
+/// Memory: borrowed options, temporary allocations are caller allocator-backed
+/// Lifetime: returned result is independent of allocator
+/// Errors: validation, size limit, and filesystem/archive write failures
+/// Caller responsibilities: hold any required store lock before calling
+pub fn writeBackup(
+    allocator: std.mem.Allocator,
+    omohi_dir: std.fs.Dir,
+    options: BackupOptions,
+) !BackupResult {
+    if (isInsidePath(options.archive_path, options.store_path)) return error.BackupTargetInsideStore;
+
+    var entries = try collectEntries(allocator, omohi_dir);
+    defer freeEntries(allocator, &entries);
+    sortEntries(entries.items);
+
+    const estimated_size = try estimateArchiveSize(entries.items);
+    if (estimated_size > options.max_size) return error.BackupTooLarge;
+
+    return writeArchive(allocator, omohi_dir, options.archive_path, entries.items);
+}
+
+// Recursively collects backup entries while excluding LOCK and `.trash`.
+fn collectEntries(allocator: std.mem.Allocator, omohi_dir: std.fs.Dir) !BackupEntryList {
+    var entries = BackupEntryList.init(allocator);
+    errdefer freeEntries(allocator, &entries);
+
+    try collectDirEntries(allocator, omohi_dir, "", &entries);
+    return entries;
+}
+
+// Collects entries below one relative directory path.
+fn collectDirEntries(
+    allocator: std.mem.Allocator,
+    root_dir: std.fs.Dir,
+    relative_dir_path: []const u8,
+    entries: *BackupEntryList,
+) !void {
+    var dir = if (relative_dir_path.len == 0)
+        try root_dir.openDir(".", .{ .iterate = true, .access_sub_paths = true })
+    else
+        try root_dir.openDir(relative_dir_path, .{ .iterate = true, .access_sub_paths = true });
+    defer dir.close();
+
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (shouldSkipEntry(relative_dir_path, entry.name)) continue;
+
+        const entry_path = try joinRelative(allocator, relative_dir_path, entry.name);
+        errdefer allocator.free(entry_path);
+
+        switch (entry.kind) {
+            .directory => {
+                const stat = try root_dir.statFile(entry_path);
+                try entries.append(.{
+                    .path = entry_path,
+                    .kind = .directory,
+                    .size = 0,
+                    .mtime = stat.mtime,
+                });
+                try collectDirEntries(allocator, root_dir, entry_path, entries);
+            },
+            .file => {
+                const stat = try root_dir.statFile(entry_path);
+                try entries.append(.{
+                    .path = entry_path,
+                    .kind = .file,
+                    .size = stat.size,
+                    .mtime = stat.mtime,
+                });
+            },
+            else => return error.UnsupportedBackupEntry,
+        }
+    }
+}
+
+// Reports entries that are deliberately excluded from backups.
+fn shouldSkipEntry(relative_dir_path: []const u8, name: []const u8) bool {
+    if (std.mem.eql(u8, name, ".trash")) return true;
+    return relative_dir_path.len == 0 and std.mem.eql(u8, name, "LOCK");
+}
+
+// Writes the tar stream through gzip into an atomic destination file.
+fn writeArchive(
+    allocator: std.mem.Allocator,
+    omohi_dir: std.fs.Dir,
+    archive_path: []const u8,
+    entries: []const BackupEntry,
+) !BackupResult {
+    const parent_path = std.fs.path.dirname(archive_path) orelse return error.InvalidPath;
+    const archive_name = std.fs.path.basename(archive_path);
+    if (archive_name.len == 0) return error.InvalidPath;
+
+    var parent_dir = try std.fs.openDirAbsolute(parent_path, .{});
+    defer parent_dir.close();
+
+    if (parent_dir.access(archive_name, .{})) |_| {
+        return error.BackupTargetExists;
+    } else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    }
+
+    const tmp_name = try makeTempName(allocator, archive_name);
+    defer allocator.free(tmp_name);
+
+    {
+        var file = try parent_dir.createFile(tmp_name, .{ .exclusive = true });
+        errdefer file.close();
+        errdefer parent_dir.deleteFile(tmp_name) catch {};
+
+        var file_buffer: [32 * 1024]u8 = undefined;
+        var file_writer = file.writer(&file_buffer);
+        var gzip: gzip_store.Writer = undefined;
+        try gzip.init(&file_writer.interface);
+
+        var tar_writer = std.tar.Writer{ .underlying_writer = &gzip.interface };
+        try tar_writer.setRoot(default_backup_root);
+        for (entries) |entry| {
+            switch (entry.kind) {
+                .directory => try tar_writer.writeDir(entry.path, .{ .mtime = mtimeSeconds(entry.mtime) }),
+                .file => try writeFileEntry(omohi_dir, &tar_writer, entry),
+            }
+        }
+        try tar_writer.finishPedantically();
+        try gzip.finish();
+        try file.sync();
+        file.close();
+    }
+
+    errdefer parent_dir.deleteFile(tmp_name) catch {};
+    try parent_dir.rename(tmp_name, archive_name);
+    try syncDir(parent_dir);
+
+    const stat = try parent_dir.statFile(archive_name);
+    return .{
+        .archive_size = stat.size,
+        .entry_count = entries.len,
+    };
+}
+
+// Writes one regular file entry from the store into the tar stream.
+fn writeFileEntry(root_dir: std.fs.Dir, tar_writer: *std.tar.Writer, entry: BackupEntry) !void {
+    var file = try root_dir.openFile(entry.path, .{});
+    defer file.close();
+
+    var read_buffer: [32 * 1024]u8 = undefined;
+    var reader = file.reader(&read_buffer);
+    try tar_writer.writeFile(entry.path, &reader, entry.mtime);
+}
+
+// Estimates the final gzip file size conservatively before writing.
+fn estimateArchiveSize(entries: []const BackupEntry) !u64 {
+    var tar_size: u64 = tar_block_size; // root directory written by setRoot
+    for (entries) |entry| {
+        tar_size += try estimateTarEntrySize(entry);
+    }
+    tar_size += tar_block_size * 2; // pedantic tar EOF blocks
+
+    const gzip_blocks = std.math.divCeil(u64, tar_size, gzip_block_payload_size) catch 0;
+    return gzip_header_size + gzip_footer_size + tar_size + gzip_blocks * 5 + 5;
+}
+
+// Estimates tar bytes for one entry, including long-name extension when needed.
+fn estimateTarEntrySize(entry: BackupEntry) !u64 {
+    var size: u64 = tar_block_size;
+    const full_path_len = default_backup_root.len + 1 + entry.path.len;
+    if (full_path_len > 255) {
+        size += tar_block_size + try paddedTarPayloadSize(full_path_len);
+    }
+    if (entry.kind == .file) {
+        size += try paddedTarPayloadSize(entry.size);
+    }
+    return size;
+}
+
+// Rounds tar payload bytes up to the next 512-byte boundary.
+fn paddedTarPayloadSize(size: u64) !u64 {
+    const blocks = try std.math.divCeil(u64, size, tar_block_size);
+    return blocks * tar_block_size;
+}
+
+// Sorts entries into deterministic path order.
+fn sortEntries(entries: []BackupEntry) void {
+    std.sort.block(BackupEntry, entries, {}, struct {
+        fn lessThan(_: void, a: BackupEntry, b: BackupEntry) bool {
+            return std.mem.lessThan(u8, a.path, b.path);
+        }
+    }.lessThan);
+}
+
+// Releases owned paths stored in the backup entry list.
+fn freeEntries(allocator: std.mem.Allocator, entries: *BackupEntryList) void {
+    for (entries.items) |entry| allocator.free(entry.path);
+    entries.deinit();
+}
+
+// Joins relative store paths using the platform separator.
+fn joinRelative(allocator: std.mem.Allocator, parent: []const u8, name: []const u8) ![]u8 {
+    if (parent.len == 0) return allocator.dupe(u8, name);
+    return std.fs.path.join(allocator, &.{ parent, name });
+}
+
+// Converts nanosecond mtime into tar seconds.
+fn mtimeSeconds(mtime: i128) u64 {
+    if (mtime <= 0) return 0;
+    return @intCast(@divFloor(mtime, std.time.ns_per_s));
+}
+
+// Builds a collision-resistant temporary file name beside the destination.
+fn makeTempName(allocator: std.mem.Allocator, archive_name: []const u8) ![]u8 {
+    var random: [8]u8 = undefined;
+    std.crypto.random.bytes(&random);
+    var hex: [random.len * 2]u8 = undefined;
+    encodeHexLower(&hex, &random);
+    return std.fmt.allocPrint(allocator, ".{s}.tmp-{s}", .{ archive_name, hex });
+}
+
+// Encodes bytes into lowercase hex.
+fn encodeHexLower(dest: []u8, source: []const u8) void {
+    const alphabet = "0123456789abcdef";
+    var idx: usize = 0;
+    for (source) |byte| {
+        dest[idx] = alphabet[@as(usize, byte >> 4)];
+        dest[idx + 1] = alphabet[@as(usize, byte & 0x0f)];
+        idx += 2;
+    }
+}
+
+// Reports whether child is equal to or nested below parent.
+fn isInsidePath(child: []const u8, parent: []const u8) bool {
+    if (std.mem.eql(u8, child, parent)) return true;
+    if (!std.mem.startsWith(u8, child, parent)) return false;
+    if (child.len <= parent.len) return false;
+    return child[parent.len] == std.fs.path.sep;
+}
+
+// Fsyncs a directory and tolerates platforms that reject directory fsync.
+fn syncDir(dir: std.fs.Dir) !void {
+    const rc = std.posix.system.fsync(dir.fd);
+    switch (std.posix.errno(rc)) {
+        .SUCCESS, .BADF, .INVAL, .ROFS => return,
+        else => |err| return std.posix.unexpectedErrno(err),
+    }
+}
+
+test "writeBackup writes store files and excludes lock and trash" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try omohi_dir.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+    try omohi_dir.writeFile(.{ .sub_path = "LOCK", .data = "locked\n" });
+    try omohi_dir.makePath("tracked/.trash");
+    try omohi_dir.writeFile(.{ .sub_path = "tracked/live", .data = "/tmp/live\n" });
+    try omohi_dir.writeFile(.{ .sub_path = "tracked/.trash/deleted", .data = "/tmp/deleted\n" });
+
+    const store_path = try tmp.dir.realpathAlloc(allocator, ".omohi");
+    defer allocator.free(store_path);
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ tmp_path, "backup.tar.gz" });
+    defer allocator.free(archive_path);
+
+    const result = try writeBackup(allocator, omohi_dir, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .max_size = 1024 * 1024,
+    });
+    try std.testing.expect(result.archive_size > 0);
+
+    const archive_bytes = try tmp.dir.readFileAlloc(allocator, "backup.tar.gz", 1024 * 1024);
+    defer allocator.free(archive_bytes);
+    var input: std.Io.Reader = .fixed(archive_bytes);
+    var output: std.Io.Writer.Allocating = .init(allocator);
+    defer output.deinit();
+    var inflate_buffer: [std.compress.flate.max_window_len]u8 = undefined;
+    var inflater: std.compress.flate.Decompress = .init(&input, .gzip, &inflate_buffer);
+    _ = try inflater.reader.streamRemaining(&output.writer);
+
+    const tar_bytes = output.writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, tar_bytes, ".omohi/VERSION") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tar_bytes, ".omohi/tracked/live") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tar_bytes, "LOCK") == null);
+    try std.testing.expect(std.mem.indexOf(u8, tar_bytes, ".trash") == null);
+}
+
+test "writeBackup rejects size limit before writing archive" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try omohi_dir.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+
+    const store_path = try tmp.dir.realpathAlloc(allocator, ".omohi");
+    defer allocator.free(store_path);
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ tmp_path, "too-small.tar.gz" });
+    defer allocator.free(archive_path);
+
+    try std.testing.expectError(error.BackupTooLarge, writeBackup(allocator, omohi_dir, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .max_size = 1,
+    }));
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("too-small.tar.gz", .{}));
+}
+
+test "writeBackup rejects output inside store" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var omohi_dir = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer omohi_dir.close();
+    try omohi_dir.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+
+    const store_path = try tmp.dir.realpathAlloc(allocator, ".omohi");
+    defer allocator.free(store_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ store_path, "backup.tar.gz" });
+    defer allocator.free(archive_path);
+
+    try std.testing.expectError(error.BackupTargetInsideStore, writeBackup(allocator, omohi_dir, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .max_size = 1024 * 1024,
+    }));
+}

--- a/src/store/storage/gzip_store.zig
+++ b/src/store/storage/gzip_store.zig
@@ -1,0 +1,128 @@
+const std = @import("std");
+
+const max_stored_block_size = 65_535;
+
+/// Streams a gzip file using uncompressed deflate stored blocks.
+/// This keeps gzip restore compatibility without depending on external tools.
+pub const Writer = struct {
+    raw: *std.Io.Writer,
+    interface: std.Io.Writer,
+    buffer: [32 * 1024]u8 = undefined,
+    crc: std.hash.Crc32 = std.hash.Crc32.init(),
+    input_size: u32 = 0,
+    finished: bool = false,
+
+    /// Initializes a gzip writer and writes the gzip header immediately.
+    /// Memory: borrowed
+    /// Lifetime: valid until `finish` and while `raw` remains valid
+    /// Errors: write failures from the underlying writer
+    /// Caller responsibilities: call `finish` exactly once after all writes
+    pub fn init(self: *Writer, raw: *std.Io.Writer) !void {
+        try raw.writeAll(&.{
+            0x1f, 0x8b, // gzip magic
+            0x08, // deflate
+            0x00, // flags
+            0x00, 0x00, 0x00, 0x00, // mtime
+            0x00, // xfl
+            0x03, // Unix
+        });
+
+        self.* = .{
+            .raw = raw,
+            .interface = .{
+                .vtable = &.{
+                    .drain = drain,
+                    .flush = flush,
+                },
+                .buffer = &.{},
+            },
+        };
+        self.interface.buffer = &self.buffer;
+    }
+
+    /// Finishes the gzip stream by writing the final empty block and footer.
+    /// Memory: borrowed
+    /// Lifetime: valid until this writer is discarded
+    /// Errors: write failures from the underlying writer
+    /// Caller responsibilities: do not write more bytes after finishing
+    pub fn finish(self: *Writer) !void {
+        if (self.finished) return;
+        try self.interface.flush();
+        try self.writeStoredBlock("", true);
+        try self.raw.writeInt(u32, self.crc.final(), .little);
+        try self.raw.writeInt(u32, self.input_size, .little);
+        try self.raw.flush();
+        self.finished = true;
+    }
+
+    // Drains buffered and direct writer data into gzip stored blocks.
+    fn drain(interface: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        const self: *Writer = @fieldParentPtr("interface", interface);
+        const buffered = interface.buffered();
+        if (buffered.len != 0) {
+            self.writeData(buffered) catch return error.WriteFailed;
+            interface.end = 0;
+        }
+
+        var consumed: usize = 0;
+        for (data, 0..) |chunk, index| {
+            const repeat = if (index == data.len - 1) splat else 1;
+            for (0..repeat) |_| {
+                self.writeData(chunk) catch return error.WriteFailed;
+                consumed += chunk.len;
+            }
+        }
+        return consumed;
+    }
+
+    // Flushes buffered bytes into the underlying gzip stream.
+    fn flush(interface: *std.Io.Writer) std.Io.Writer.Error!void {
+        const self: *Writer = @fieldParentPtr("interface", interface);
+        const buffered = interface.buffered();
+        if (buffered.len == 0) return;
+        self.writeData(buffered) catch return error.WriteFailed;
+        interface.end = 0;
+    }
+
+    // Splits input into deflate stored blocks and updates gzip accounting.
+    fn writeData(self: *Writer, bytes: []const u8) !void {
+        var remaining = bytes;
+        while (remaining.len != 0) {
+            const chunk_len = @min(remaining.len, max_stored_block_size);
+            const chunk = remaining[0..chunk_len];
+            try self.writeStoredBlock(chunk, false);
+            self.crc.update(chunk);
+            self.input_size +%= @truncate(chunk.len);
+            remaining = remaining[chunk_len..];
+        }
+    }
+
+    // Writes one byte-aligned deflate stored block.
+    fn writeStoredBlock(self: *Writer, bytes: []const u8, final: bool) !void {
+        std.debug.assert(bytes.len <= max_stored_block_size);
+        const len: u16 = @intCast(bytes.len);
+        try self.raw.writeByte(if (final) 0x01 else 0x00);
+        try self.raw.writeInt(u16, len, .little);
+        try self.raw.writeInt(u16, ~len, .little);
+        try self.raw.writeAll(bytes);
+    }
+};
+
+test "gzip store writer produces decompressible gzip bytes" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    var gzip: Writer = undefined;
+    try gzip.init(&out.writer);
+    try gzip.interface.writeAll("hello gzip");
+    try gzip.finish();
+
+    var input: std.Io.Reader = .fixed(out.writer.buffered());
+    var decompressed: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer decompressed.deinit();
+    var buffer: [std.compress.flate.max_window_len]u8 = undefined;
+    var inflater: std.compress.flate.Decompress = .init(&input, .gzip, &buffer);
+    _ = try inflater.reader.streamRemaining(&decompressed.writer);
+
+    try std.testing.expectEqualStrings("hello gzip", decompressed.writer.buffered());
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5,6 +5,7 @@ const _store_constrained_types = @import("store/object/constrained_types.zig");
 const _store_hash = @import("store/object/hash.zig");
 // storage
 const _store_atomic = @import("store/storage/atomic_write.zig");
+const _store_gzip_store = @import("store/storage/gzip_store.zig");
 const _store_lock = @import("store/storage/lock.zig");
 const _store_time_utc = @import("store/storage/time/utc.zig");
 const _store_time_local_timestamp = @import("store/storage/time/local_timestamp.zig");
@@ -21,6 +22,7 @@ const _store_local_directory_tree_files = @import("store/local/directory_tree_fi
 const _store_local_trash = @import("store/local/trash.zig");
 const _store_local_version = @import("store/local/version.zig");
 const _store_local_journal = @import("store/local/journal.zig");
+const _store_local_backup = @import("store/local/backup.zig");
 // testing
 const _testing_persistence_fixture_inspector = @import("testing/persistence_fixture_inspector.zig");
 const _testing_store_api_test_support = @import("testing/store_api_test_support.zig");
@@ -37,6 +39,7 @@ const _ops_tag = @import("ops/tag_ops.zig");
 const _ops_completion = @import("ops/completion_ops.zig");
 const _ops_journal_append = @import("ops/journal/append.zig");
 const _ops_journal = @import("ops/journal_ops.zig");
+const _ops_backup = @import("ops/backup_ops.zig");
 
 // app/cli tests
 const _app_cli_run = @import("app/cli/run.zig");
@@ -51,6 +54,7 @@ const _app_cli_ansi_color = @import("app/cli/presenter/ansi_color.zig");
 const _app_cli_output = @import("app/cli/presenter/output.zig");
 const _app_cli_version = @import("app/cli/command/version.zig");
 const _app_cli_journal = @import("app/cli/command/journal.zig");
+const _app_cli_backup = @import("app/cli/command/backup.zig");
 const _app_cli_command_catalog = @import("app/cli/command_catalog.zig");
 const _app_cli_docs_render_markdown = @import("app/cli/docs/render_markdown.zig");
 const _app_cli_docs_render_man = @import("app/cli/docs/render_man.zig");
@@ -60,6 +64,7 @@ test "load modules" {
     _ = _store_constrained_types;
     _ = _store_hash;
     _ = _store_atomic;
+    _ = _store_gzip_store;
     _ = _store_lock;
     _ = _store_time_utc;
     _ = _store_time_local_timestamp;
@@ -75,6 +80,7 @@ test "load modules" {
     _ = _store_local_trash;
     _ = _store_local_version;
     _ = _store_local_journal;
+    _ = _store_local_backup;
     _ = _testing_persistence_fixture_inspector;
     _ = _testing_store_api_test_support;
     _ = _ops_track;
@@ -88,6 +94,7 @@ test "load modules" {
     _ = _ops_completion;
     _ = _ops_journal_append;
     _ = _ops_journal;
+    _ = _ops_backup;
     _ = _app_cli_run;
     _ = _app_cli_error_map;
     _ = _app_cli_error_message;
@@ -100,6 +107,7 @@ test "load modules" {
     _ = _app_cli_output;
     _ = _app_cli_version;
     _ = _app_cli_journal;
+    _ = _app_cli_backup;
     _ = _app_cli_command_catalog;
     _ = _app_cli_docs_render_markdown;
     _ = _app_cli_docs_render_man;


### PR DESCRIPTION
## Summary

- Add `omohi backup <archivePath>` with an optional `--max-size <bytes>` guard.
- Create full `.tar.gz` backups of `~/.omohi` while excluding `LOCK` and `.trash` entries.
- Wire the command through parser, CLI dispatch, ops, store facade, help docs, man page, and shell completion.
- Add store/unit coverage plus E2E and completion coverage for the new command.

## Validation

- `make test`
- `make fmt-check`
- `make test-contract`
- `make test-completion`
- `make test-reliability`
- `make test-e2e-matrix`
- `make docs`
