### PR TITLE
Add restore command for backup archives

### DIFF
--- a/.github/scripts/omohi_e2e_matrix.sh
+++ b/.github/scripts/omohi_e2e_matrix.sh
@@ -1118,6 +1118,55 @@ case_081_backup_rejects_small_max_size() {
   assert_file_missing "$archive" "backup should not leave archive when size guard fails"
 }
 
+case_081_restore_full_archive() {
+  local archive
+  setup_commit_without_tags
+  archive="$WORK_DIR/restore.tar.gz"
+
+  run_omohi_capture backup "$archive"
+  assert_eq "0" "$RUN_CODE" "backup should succeed before restore"
+  rm -rf "$HOME_DIR/.omohi"
+
+  run_omohi_capture restore "$archive"
+  assert_eq "0" "$RUN_CODE" "restore should succeed"
+  assert_contains "$RUN_STDOUT" "Restored ~/.omohi from $archive" "restore should report source archive"
+  assert_file_exists "$HOME_DIR/.omohi/VERSION" "restore should recreate store metadata"
+
+  run_omohi_capture find
+  assert_eq "0" "$RUN_CODE" "find should work after restore"
+  assert_contains "$RUN_STDOUT" "Found 1 commit(s)." "restore should preserve commits"
+}
+
+case_081_restore_rejects_existing_target() {
+  local archive
+  setup_commit_without_tags
+  archive="$WORK_DIR/restore-existing.tar.gz"
+
+  run_omohi_capture backup "$archive"
+  assert_eq "0" "$RUN_CODE" "backup should succeed before restore rejection"
+
+  run_omohi_capture restore "$archive"
+  assert_eq "4" "$RUN_CODE" "restore should reject existing store"
+  assert_contains "$RUN_STDERR" "Store already exists." "restore should explain existing target"
+}
+
+case_081_restore_replace_moves_existing_store() {
+  local archive rollback_path
+  setup_commit_without_tags
+  archive="$WORK_DIR/restore-replace.tar.gz"
+
+  run_omohi_capture backup "$archive"
+  assert_eq "0" "$RUN_CODE" "backup should succeed before restore replace"
+  printf 'old\n' > "$HOME_DIR/.omohi/OLD_MARKER"
+
+  run_omohi_capture restore --replace "$archive"
+  assert_eq "0" "$RUN_CODE" "restore --replace should succeed"
+  assert_contains "$RUN_STDOUT" "Previous store moved to " "restore --replace should report rollback path"
+  rollback_path="$(printf '%s\n' "$RUN_STDOUT" | awk '/Previous store moved to / { sub(/^Previous store moved to /, ""); print; exit }')"
+  assert_file_exists "$rollback_path/OLD_MARKER" "restore --replace should leave previous store rollback"
+  assert_file_missing "$HOME_DIR/.omohi/OLD_MARKER" "restore --replace should install restored store"
+}
+
 case_082_tag_ls_with_tags() {
   setup_commit_with_two_files_and_tags
   run_omohi_capture tag ls "$LAST_COMMIT_ID"
@@ -1366,6 +1415,9 @@ run_case "journal rejects extra args" case_081_journal_rejects_extra_args
 run_case "backup full archive" case_081_backup_full_archive
 run_case "backup rejects existing target" case_081_backup_rejects_existing_target
 run_case "backup rejects small max size" case_081_backup_rejects_small_max_size
+run_case "restore full archive" case_081_restore_full_archive
+run_case "restore rejects existing target" case_081_restore_rejects_existing_target
+run_case "restore replace moves existing store" case_081_restore_replace_moves_existing_store
 run_case "tag ls with tags" case_082_tag_ls_with_tags
 run_case "tag field only" case_083_tag_field_only
 run_case "tag ls without tags" case_084_tag_ls_without_tags

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Agents should also refer to directories under `docs/` when they are relevant to 
 
 ## 4. CLI Contract (Must Preserve)
 - Target commands:
-  - `track`, `untrack`, `add`, `rm`, `commit`, `status`, `tracklist`, `find`, `show`, `tag ls`, `tag add`, `tag rm`, `help`
+  - `track`, `untrack`, `add`, `rm`, `commit`, `status`, `tracklist`, `find`, `show`, `backup`, `restore`, `tag ls`, `tag add`, `tag rm`, `help`
 - Parser behavior:
   - Resolve commands by longest match (including subcommands).
   - Support `--key=value`, `--key value`, and `-k value`.

--- a/completions/omohi.bash
+++ b/completions/omohi.bash
@@ -8,7 +8,7 @@ _omohi_complete() {
   fi
   cword=${COMP_CWORD}
 
-  local top_level_commands="track untrack add rm commit status tracklist version find show journal backup tag help"
+  local top_level_commands="track untrack add rm commit status tracklist version find show journal backup restore tag help"
   local top_level_aliases="-h --help -v --version"
   local completion_command="${OMOHI_COMPLETION_COMMAND:-omohi}"
 
@@ -60,6 +60,19 @@ _omohi_complete() {
       return 0
       ;;
     backup)
+      if [[ "${prev}" == "--max-size" ]]; then
+        _omohi_collect_candidates
+        return 0
+      fi
+      if [[ -z "${cur}" || "${cur}" == -* ]]; then
+        _omohi_collect_candidates
+        return 0
+      fi
+      compopt -o filenames 2>/dev/null || true
+      COMPREPLY=( $(compgen -f -- "${cur}") )
+      return 0
+      ;;
+    restore)
       if [[ "${prev}" == "--max-size" ]]; then
         _omohi_collect_candidates
         return 0

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,7 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
 | `show` | `show [--output <text|json>] [--field <commit_id|message|created_at|paths|tags>]... <commitId>` | Show one commit details payload. |
 | `journal` | `journal` | Show recent journal logs in reverse chronological order. |
 | `backup` | `backup [--max-size <bytes>] <archivePath>` | Create a full tar.gz backup archive of ~/.omohi. |
+| `restore` | `restore [--replace] [--max-size <bytes>] <archivePath>` | Restore ~/.omohi from a full tar.gz backup archive. |
 | `tag` | `tag [--field <tag>]...` | List all known tag names. |
 | `tag ls` | `tag ls [--field <tag>]... <commitId>` | List tags for one commit. |
 | `tag add` | `tag add <commitId> <tagNames...>` | Attach one or more tags to a commit. |
@@ -252,6 +253,25 @@ This file is generated from `src/app/cli/command_catalog.zig`. Do not edit manua
   - The target archive must not already exist and must be outside ~/.omohi.
   - `LOCK` and `.trash` directories are excluded from the archive.
   - Backups are always full backups in this version.
+
+### restore
+
+- Usage: `omohi restore [--replace] [--max-size <bytes>] <archivePath>`
+- Summary: Restore ~/.omohi from a full tar.gz backup archive.
+- Positionals:
+  - `archivePath` (required): Path to the backup archive to restore.
+- Options:
+  - `--replace` (optional): Replace an existing non-empty ~/.omohi after moving it to a rollback directory.
+  - `--max-size` `<bytes>` (optional): Reject the restore if the archive or extracted file payload exceeds this byte count. Defaults to 1073741824.
+- Examples:
+  - `omohi restore ~/omohi-backup.tar.gz`
+  - `omohi restore --replace ~/omohi-backup.tar.gz`
+  - `omohi restore --max-size 2147483648 ~/omohi-backup.tar.gz`
+- Notes:
+  - The archive must be a full backup produced by `omohi backup`.
+  - Existing non-empty ~/.omohi is rejected unless `--replace` is set.
+  - `--replace` moves the previous store to a rollback directory beside ~/.omohi before installing the restored store.
+  - Stored absolute paths are restored unchanged; paths from another environment may appear as `missing` in `omohi status`.
 
 ### tag
 

--- a/docs/man/omohi.1
+++ b/docs/man/omohi.1
@@ -496,6 +496,52 @@ The target archive must not already exist and must be outside ~/.omohi.
 .RS 4
 Backups are always full backups in this version.
 .RE
+.SS restore
+.TP
+.B Summary
+Restore ~/.omohi from a full tar.gz backup archive.
+.TP
+.B Usage
+.nf
+omohi restore [\-\-replace] [\-\-max\-size <bytes>] <archivePath>
+.fi
+.TP
+.B Positionals
+.RS 4
+.B archivePath
+required: Path to the backup archive to restore.
+.RE
+.TP
+.B Options
+.RS 4
+.B \-\-replace
+optional: Replace an existing non\-empty ~/.omohi after moving it to a rollback directory.
+.RE
+.RS 4
+.B \-\-max\-size <bytes>
+optional: Reject the restore if the archive or extracted file payload exceeds this byte count. Defaults to 1073741824.
+.RE
+.TP
+.B Examples
+.nf
+omohi restore ~/omohi\-backup.tar.gz
+omohi restore \-\-replace ~/omohi\-backup.tar.gz
+omohi restore \-\-max\-size 2147483648 ~/omohi\-backup.tar.gz
+.fi
+.TP
+.B Notes
+.RS 4
+The archive must be a full backup produced by `omohi backup`.
+.RE
+.RS 4
+Existing non\-empty ~/.omohi is rejected unless `\-\-replace` is set.
+.RE
+.RS 4
+`\-\-replace` moves the previous store to a rollback directory beside ~/.omohi before installing the restored store.
+.RE
+.RS 4
+Stored absolute paths are restored unchanged; paths from another environment may appear as `missing` in `omohi status`.
+.RE
 .SS tag
 .TP
 .B Summary

--- a/src/app/cli/command/restore.zig
+++ b/src/app/cli/command/restore.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+
+const parser_types = @import("../parser/types.zig");
+const command_types = @import("../runtime/types.zig");
+const environment = @import("../environment.zig");
+const path_resolver = @import("../path_resolver.zig");
+const presenter = @import("../presenter/output.zig");
+const exit_code = @import("../error/exit_code.zig");
+const restore_ops = @import("../../../ops/restore_ops.zig");
+
+// Runs the `restore` command and returns owned CLI output for the caller to free.
+pub fn run(allocator: std.mem.Allocator, args: parser_types.RestoreArgs) !command_types.CommandResult {
+    const store_path = try environment.resolveOmohiPath(allocator);
+    defer allocator.free(store_path);
+
+    const archive_path = try path_resolver.resolveAbsolutePath(allocator, args.archive_path);
+    defer allocator.free(archive_path);
+
+    var result = try restore_ops.restore(
+        allocator,
+        store_path,
+        archive_path,
+        args.replace,
+        args.max_size,
+    );
+    defer restore_ops.freeRestoreResult(allocator, &result);
+
+    const output = try presenter.restoreResult(allocator, archive_path, result);
+    return .{ .output = output, .to_stderr = false, .exit_code = exit_code.ok };
+}

--- a/src/app/cli/command_catalog.zig
+++ b/src/app/cli/command_catalog.zig
@@ -42,6 +42,7 @@ pub const public_command_tags = [_]ParsedRequestTag{
     .show,
     .journal,
     .backup,
+    .restore,
     .tag,
     .tag_ls,
     .tag_add,
@@ -277,6 +278,29 @@ pub const all = [_]CommandSpec{
             "The target archive must not already exist and must be outside ~/.omohi.",
             "`LOCK` and `.trash` directories are excluded from the archive.",
             "Backups are always full backups in this version.",
+        },
+    },
+    .{
+        .name = "restore",
+        .usage = "restore [--replace] [--max-size <bytes>] <archivePath>",
+        .summary = "Restore ~/.omohi from a full tar.gz backup archive.",
+        .positionals = &.{
+            .{ .name = "archivePath", .required = true, .repeatable = false, .description = "Path to the backup archive to restore." },
+        },
+        .options = &.{
+            .{ .long = "replace", .short = null, .value_name = null, .required = false, .repeatable = false, .description = "Replace an existing non-empty ~/.omohi after moving it to a rollback directory." },
+            .{ .long = "max-size", .short = null, .value_name = "bytes", .required = false, .repeatable = false, .description = "Reject the restore if the archive or extracted file payload exceeds this byte count. Defaults to 1073741824." },
+        },
+        .examples = &.{
+            "omohi restore ~/omohi-backup.tar.gz",
+            "omohi restore --replace ~/omohi-backup.tar.gz",
+            "omohi restore --max-size 2147483648 ~/omohi-backup.tar.gz",
+        },
+        .notes = &.{
+            "The archive must be a full backup produced by `omohi backup`.",
+            "Existing non-empty ~/.omohi is rejected unless `--replace` is set.",
+            "`--replace` moves the previous store to a rollback directory beside ~/.omohi before installing the restored store.",
+            "Stored absolute paths are restored unchanged; paths from another environment may appear as `missing` in `omohi status`.",
         },
     },
     .{
@@ -531,6 +555,8 @@ fn optionTakesValue(comptime command_name: []const u8, comptime option_long: []c
     if (std.mem.eql(u8, command_name, "show") and std.mem.eql(u8, option_long, "output")) return true;
     if (std.mem.eql(u8, command_name, "show") and std.mem.eql(u8, option_long, "field")) return true;
     if (std.mem.eql(u8, command_name, "backup") and std.mem.eql(u8, option_long, "max-size")) return true;
+    if (std.mem.eql(u8, command_name, "restore") and std.mem.eql(u8, option_long, "replace")) return false;
+    if (std.mem.eql(u8, command_name, "restore") and std.mem.eql(u8, option_long, "max-size")) return true;
     if (std.mem.eql(u8, command_name, "tag") and std.mem.eql(u8, option_long, "field")) return true;
     if (std.mem.eql(u8, command_name, "tag ls") and std.mem.eql(u8, option_long, "field")) return true;
     @compileError(std.fmt.comptimePrint(

--- a/src/app/cli/error/error_map.zig
+++ b/src/app/cli/error/error_map.zig
@@ -5,6 +5,7 @@ const exit_code = @import("exit_code.zig");
 pub fn exitCodeFor(err: anyerror) u8 {
     if (err == error.DataDestroyed) return exit_code.data_destroyed;
     if (err == error.MissingStoreVersion) return exit_code.data_destroyed;
+    if (err == error.InvalidRestoreArchive) return exit_code.use_case_error;
 
     const name = @errorName(err);
     if (std.mem.startsWith(u8, name, "Invalid")) return exit_code.domain_error;
@@ -19,7 +20,11 @@ pub fn exitCodeFor(err: anyerror) u8 {
         err == error.BackupTooLarge or
         err == error.BackupTargetExists or
         err == error.BackupTargetInsideStore or
-        err == error.UnsupportedBackupEntry)
+        err == error.UnsupportedBackupEntry or
+        err == error.RestoreTooLarge or
+        err == error.RestoreTargetExists or
+        err == error.UnsupportedRestoreEntry or
+        err == error.InvalidRestoreArchive)
     {
         return exit_code.use_case_error;
     }

--- a/src/app/cli/error/error_message.zig
+++ b/src/app/cli/error/error_message.zig
@@ -37,6 +37,10 @@ pub fn forRuntimeError(err: anyerror) []const u8 {
         error.BackupTargetExists => "Backup target already exists. Choose a new archive path.",
         error.BackupTargetInsideStore => "Backup target must be outside ~/.omohi.",
         error.UnsupportedBackupEntry => "Store contains an unsupported entry type for backup.",
+        error.RestoreTooLarge => "Restore archive is too large. Use --max-size to raise the limit or choose a smaller backup.",
+        error.RestoreTargetExists => "Store already exists. Use --replace to move the current store aside and restore the backup.",
+        error.InvalidRestoreArchive => "Restore archive is invalid. Use an archive created by `omohi backup`.",
+        error.UnsupportedRestoreEntry => "Restore archive contains an unsupported entry type or excluded store path.",
         else => "Operation failed due to an unexpected system error.",
     };
 }

--- a/src/app/cli/parser/parse.zig
+++ b/src/app/cli/parser/parse.zig
@@ -44,6 +44,7 @@ pub fn parseArgs(allocator: std.mem.Allocator, argv: []const []const u8) !types.
     if (std.mem.eql(u8, argv[0], "show")) return try parseShow(allocator, argv[1..]);
     if (std.mem.eql(u8, argv[0], "journal")) return try parseJournal(argv[1..]);
     if (std.mem.eql(u8, argv[0], "backup")) return try parseBackup(argv[1..]);
+    if (std.mem.eql(u8, argv[0], "restore")) return try parseRestore(argv[1..]);
 
     return error.InvalidCommand;
 }
@@ -319,6 +320,50 @@ fn parseBackup(args: []const []const u8) !types.ParsedRequest {
 
     return .{ .backup = .{
         .archive_path = archive_path orelse return error.MissingArgument,
+        .max_size = max_size,
+    } };
+}
+
+// Parses `restore <archivePath>` plus replacement and size guard options.
+fn parseRestore(args: []const []const u8) !types.ParsedRequest {
+    var max_size: u64 = 1024 * 1024 * 1024;
+    var archive_path: ?[]const u8 = null;
+    var replace = false;
+    var idx: usize = 0;
+    var stop_option = false;
+    while (idx < args.len) : (idx += 1) {
+        const token = args[idx];
+
+        if (!stop_option and scan.isDoubleDash(token)) {
+            stop_option = true;
+            continue;
+        }
+
+        if (!stop_option) {
+            if (scan.parseLongOption(token)) |opt| {
+                if (scan.equalsIgnoreAsciiCase(opt.key, "max-size")) {
+                    const value = try scan.optionValue(args, &idx, opt.value);
+                    max_size = std.fmt.parseInt(u64, value, 10) catch return error.InvalidArgument;
+                    if (max_size == 0) return error.InvalidArgument;
+                    continue;
+                }
+                if (scan.equalsIgnoreAsciiCase(opt.key, "replace")) {
+                    if (opt.value != null) return error.InvalidArgument;
+                    replace = true;
+                    continue;
+                }
+
+                return error.UnknownOption;
+            }
+        }
+
+        if (archive_path != null) return error.UnexpectedArgument;
+        archive_path = token;
+    }
+
+    return .{ .restore = .{
+        .archive_path = archive_path orelse return error.MissingArgument,
+        .replace = replace,
         .max_size = max_size,
     } };
 }
@@ -1277,6 +1322,31 @@ test "parser rejects invalid backup inputs" {
     try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "backup", "--max-size", "0", "backup.tar.gz" }));
     try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "backup", "--max-size", "abc", "backup.tar.gz" }));
     try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "backup", "a.tar.gz", "b.tar.gz" }));
+}
+
+test "parser accepts restore archive path replace and max size" {
+    const allocator = std.testing.allocator;
+    const argv = [_][]const u8{ "restore", "--replace", "--max-size=2048", "backup.tar.gz" };
+    var parsed = try parseArgs(allocator, &argv);
+    defer types.deinitParsedRequest(allocator, &parsed);
+
+    switch (parsed) {
+        .restore => |args| {
+            try std.testing.expectEqualStrings("backup.tar.gz", args.archive_path);
+            try std.testing.expect(args.replace);
+            try std.testing.expectEqual(@as(u64, 2048), args.max_size);
+        },
+        else => return error.UnexpectedResult,
+    }
+}
+
+test "parser rejects invalid restore inputs" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.MissingArgument, parseArgs(allocator, &.{"restore"}));
+    try std.testing.expectError(error.MissingValue, parseArgs(allocator, &.{ "restore", "--max-size" }));
+    try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "restore", "--max-size", "0", "backup.tar.gz" }));
+    try std.testing.expectError(error.InvalidArgument, parseArgs(allocator, &.{ "restore", "--replace=true", "backup.tar.gz" }));
+    try std.testing.expectError(error.UnexpectedArgument, parseArgs(allocator, &.{ "restore", "a.tar.gz", "b.tar.gz" }));
 }
 
 test "parser accepts find output and repeated fields" {

--- a/src/app/cli/parser/types.zig
+++ b/src/app/cli/parser/types.zig
@@ -88,6 +88,12 @@ pub const BackupArgs = struct {
     max_size: u64,
 };
 
+pub const RestoreArgs = struct {
+    archive_path: []const u8,
+    replace: bool,
+    max_size: u64,
+};
+
 pub const TagArgs = struct {
     fields: []const TagField,
 };
@@ -129,6 +135,7 @@ pub const ParsedRequest = union(enum) {
     show: ShowArgs,
     journal: JournalArgs,
     backup: BackupArgs,
+    restore: RestoreArgs,
     tag: TagArgs,
     tag_ls: TagLsArgs,
     tag_add: TagAddArgs,

--- a/src/app/cli/presenter/output.zig
+++ b/src/app/cli/presenter/output.zig
@@ -11,6 +11,7 @@ const show_ops = @import("../../../ops/show_ops.zig");
 const tag_ops = @import("../../../ops/tag_ops.zig");
 const journal_ops = @import("../../../ops/journal_ops.zig");
 const backup_ops = @import("../../../ops/backup_ops.zig");
+const restore_ops = @import("../../../ops/restore_ops.zig");
 
 pub const TagRemoveOutcome = enum {
     no_tags,
@@ -256,6 +257,30 @@ pub fn backupResult(
         "Backed up ~/.omohi to {s} ({d} bytes).\n",
         .{ archive_path, result.archive_size },
     );
+}
+
+// Renders restore completion as owned CLI output.
+pub fn restoreResult(
+    allocator: std.mem.Allocator,
+    archive_path: []const u8,
+    result: restore_ops.RestoreResult,
+) ![]u8 {
+    var out = std.array_list.Managed(u8).init(allocator);
+    errdefer out.deinit();
+    const writer = out.writer();
+
+    try writer.print(
+        "Restored ~/.omohi from {s} ({d} entries).\n",
+        .{ archive_path, result.entry_count },
+    );
+    if (result.missing_tracked_count != 0) {
+        try writer.print("Missing tracked target(s): {d}\n", .{result.missing_tracked_count});
+    }
+    if (result.rollback_path) |path| {
+        try writer.print("Previous store moved to {s}\n", .{path});
+    }
+
+    return out.toOwnedSlice();
 }
 
 // Renders journal entries as owned CLI output.

--- a/src/app/cli/runtime/dispatch.zig
+++ b/src/app/cli/runtime/dispatch.zig
@@ -13,6 +13,7 @@ const find = @import("../command/find.zig");
 const show = @import("../command/show.zig");
 const journal = @import("../command/journal.zig");
 const backup = @import("../command/backup.zig");
+const restore = @import("../command/restore.zig");
 const tag = @import("../command/tag.zig");
 const tag_ls = @import("../command/tag_ls.zig");
 const tag_add = @import("../command/tag_add.zig");
@@ -35,6 +36,7 @@ pub fn dispatch(allocator: std.mem.Allocator, parsed: parser_types.ParsedRequest
         .show => |args| try show.run(allocator, args),
         .journal => |args| try journal.run(allocator, args),
         .backup => |args| try backup.run(allocator, args),
+        .restore => |args| try restore.run(allocator, args),
         .tag => |args| try tag.run(allocator, args),
         .tag_ls => |args| try tag_ls.run(allocator, args),
         .tag_add => |args| try tag_add.run(allocator, args),

--- a/src/ops/completion_ops.zig
+++ b/src/ops/completion_ops.zig
@@ -5,7 +5,7 @@ const store_api = @import("../store/api.zig");
 pub const CandidateList = std.array_list.Managed([]u8);
 
 const top_level_commands = [_][]const u8{
-    "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "backup", "tag", "help",
+    "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "backup", "restore", "tag", "help",
 };
 const top_level_aliases = [_][]const u8{ "-h", "--help", "-v", "--version" };
 const tag_commands = [_][]const u8{ "ls", "add", "rm" };
@@ -17,13 +17,14 @@ const tracklist_options = [_][]const u8{ "--output", "--field" };
 const find_options = [_][]const u8{ "-t", "--tag", "--empty", "--no-empty", "-s", "--since", "-u", "--until", "--limit", "--output", "--field" };
 const show_options = [_][]const u8{ "--output", "--field" };
 const backup_options = [_][]const u8{"--max-size"};
+const restore_options = [_][]const u8{ "--replace", "--max-size" };
 const tag_options = [_][]const u8{"--field"};
 const output_values = [_][]const u8{ "text", "json" };
 const tracklist_field_values = [_][]const u8{ "id", "path" };
 const find_field_values = [_][]const u8{ "commit_id", "message", "created_at" };
 const show_field_values = [_][]const u8{ "commit_id", "message", "created_at", "paths", "tags" };
 const tag_field_values = [_][]const u8{"tag"};
-const help_topics = [_][]const u8{ "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "backup", "tag", "help" };
+const help_topics = [_][]const u8{ "track", "untrack", "add", "rm", "commit", "status", "tracklist", "version", "find", "show", "journal", "backup", "restore", "tag", "help" };
 
 // Reports whether completion at the current cursor position needs store-backed data.
 pub fn requiresStore(words: []const []const u8, index: usize) bool {
@@ -151,6 +152,11 @@ pub fn complete(
     if (std.mem.eql(u8, command, "backup")) {
         if (expectsValue(words, index, "--max-size", "")) return out;
         try appendFilteredStatic(allocator, &out, &backup_options, current);
+        return out;
+    }
+    if (std.mem.eql(u8, command, "restore")) {
+        if (expectsValue(words, index, "--max-size", "")) return out;
+        try appendFilteredStatic(allocator, &out, &restore_options, current);
         return out;
     }
     if (std.mem.eql(u8, command, "rm") and index == 2) {
@@ -560,6 +566,28 @@ test "complete returns backup options" {
 
     {
         const words = [_][]const u8{ "omohi", "backup", "--max-size", "" };
+        var list = try complete(allocator, null, &words, 3);
+        defer freeCandidateList(allocator, &list);
+
+        try std.testing.expectEqual(@as(usize, 0), list.items.len);
+    }
+}
+
+test "complete returns restore options" {
+    const allocator = std.testing.allocator;
+
+    {
+        const words = [_][]const u8{ "omohi", "restore", "--" };
+        var list = try complete(allocator, null, &words, 2);
+        defer freeCandidateList(allocator, &list);
+
+        try std.testing.expectEqual(@as(usize, 2), list.items.len);
+        try std.testing.expectEqualStrings("--replace", list.items[0]);
+        try std.testing.expectEqualStrings("--max-size", list.items[1]);
+    }
+
+    {
+        const words = [_][]const u8{ "omohi", "restore", "--max-size", "" };
         var list = try complete(allocator, null, &words, 3);
         defer freeCandidateList(allocator, &list);
 

--- a/src/ops/restore_ops.zig
+++ b/src/ops/restore_ops.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+const store_api = @import("../store/api.zig");
+
+/// Default archive and extracted size limit for the restore command.
+pub const default_max_size: u64 = 1024 * 1024 * 1024;
+
+/// Describes a completed restore operation.
+pub const RestoreResult = store_api.RestoreResult;
+
+/// Restores a full backup archive into the current user-level store.
+pub fn restore(
+    allocator: std.mem.Allocator,
+    store_path: []const u8,
+    archive_path: []const u8,
+    replace_existing: bool,
+    max_size: u64,
+) !RestoreResult {
+    return store_api.restoreStore(allocator, store_path, archive_path, replace_existing, max_size);
+}
+
+/// Releases owned memory from a restore result.
+pub fn freeRestoreResult(allocator: std.mem.Allocator, result: *RestoreResult) void {
+    store_api.freeRestoreResult(allocator, result);
+}

--- a/src/store/api.zig
+++ b/src/store/api.zig
@@ -19,6 +19,7 @@ const local_journal = @import("./local/journal.zig");
 const local_directory_tree_files = @import("./local/directory_tree_files.zig");
 const local_version = @import("./local/version.zig");
 const local_backup = @import("./local/backup.zig");
+const local_restore = @import("./local/restore.zig");
 const version_guard = @import("./storage/version_guard.zig");
 const ContentEntry = @import("./object/content_entry.zig").ContentEntry;
 const hash = @import("./object/hash.zig");
@@ -123,6 +124,8 @@ pub const JournalEntryList = local_journal.JournalEntryList;
 
 /// Describes a completed backup archive.
 pub const BackupResult = local_backup.BackupResult;
+/// Describes a completed restore operation.
+pub const RestoreResult = local_restore.RestoreResult;
 
 /// Carries commit metadata, entries, and tags for `show`.
 pub const CommitDetails = struct {
@@ -216,6 +219,35 @@ pub fn backupStore(
         .archive_path = archive_path,
         .max_size = max_size,
     });
+}
+
+/// Restores a full backup archive into the user-level store directory.
+/// Memory: borrowed path inputs, returned result may own rollback_path
+/// Lifetime: rollback_path remains valid until freeRestoreResult
+/// Errors: validation, version, size limit, and filesystem/archive failures
+/// Caller responsibilities: pass absolute normalized store and archive paths
+pub fn restoreStore(
+    allocator: std.mem.Allocator,
+    store_path: []const u8,
+    archive_path: []const u8,
+    replace_existing: bool,
+    max_size: u64,
+) !RestoreResult {
+    return local_restore.restoreBackup(allocator, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .replace_existing = replace_existing,
+        .max_size = max_size,
+    });
+}
+
+/// Releases owned memory from a restore result.
+/// Memory: frees allocator-owned rollback path when present
+/// Lifetime: result is invalid after this call
+/// Errors: none
+/// Caller responsibilities: call once for restoreStore results
+pub fn freeRestoreResult(allocator: std.mem.Allocator, result: *RestoreResult) void {
+    local_restore.freeRestoreResult(allocator, result);
 }
 
 // Reports whether the opened store directory currently has no entries.

--- a/src/store/local/restore.zig
+++ b/src/store/local/restore.zig
@@ -1,0 +1,512 @@
+const std = @import("std");
+
+const constrained_types = @import("../object/constrained_types.zig");
+const version_guard = @import("../storage/version_guard.zig");
+
+const backup_root = ".omohi";
+const temp_suffix_prefix = ".restore-tmp-";
+const rollback_suffix_prefix = ".restore-rollback-";
+const max_tracked_file_size = 16 * 1024;
+
+/// Carries normalized restore paths and restore safety options.
+pub const RestoreOptions = struct {
+    store_path: []const u8,
+    archive_path: []const u8,
+    replace_existing: bool,
+    max_size: u64,
+};
+
+/// Reports a completed restore and owns rollback_path when present.
+pub const RestoreResult = struct {
+    entry_count: usize,
+    missing_tracked_count: usize,
+    rollback_path: ?[]u8,
+};
+
+/// Releases optional owned memory in a restore result.
+/// Memory: frees allocator-backed fields in result
+/// Lifetime: result must not be used after this call
+/// Errors: none
+/// Caller responsibilities: call once for results returned by restoreBackup
+pub fn freeRestoreResult(allocator: std.mem.Allocator, result: *RestoreResult) void {
+    if (result.rollback_path) |path| allocator.free(path);
+    result.* = undefined;
+}
+
+/// Restores a gzip-compressed tar backup into the user-level store directory.
+/// Memory: borrowed options, returned rollback path is allocator-owned
+/// Lifetime: rollback path remains valid until freeRestoreResult
+/// Errors: validation, archive, version, size, and filesystem failures
+/// Caller responsibilities: pass absolute normalized store and archive paths
+pub fn restoreBackup(
+    allocator: std.mem.Allocator,
+    options: RestoreOptions,
+) !RestoreResult {
+    if (options.max_size == 0) return error.RestoreTooLarge;
+
+    const parent_path = std.fs.path.dirname(options.store_path) orelse return error.InvalidPath;
+    const store_name = std.fs.path.basename(options.store_path);
+    if (store_name.len == 0) return error.InvalidPath;
+
+    var parent_dir = try std.fs.openDirAbsolute(parent_path, .{ .iterate = true, .access_sub_paths = true });
+    defer parent_dir.close();
+
+    try validateExistingStore(parent_dir, store_name, options.replace_existing);
+    {
+        var archive = try std.fs.openFileAbsolute(options.archive_path, .{});
+        defer archive.close();
+        const archive_stat = try archive.stat();
+        if (archive_stat.size > options.max_size) return error.RestoreTooLarge;
+    }
+
+    const temp_name = try makeUniqueSiblingName(allocator, parent_dir, store_name, temp_suffix_prefix);
+    defer allocator.free(temp_name);
+    try parent_dir.makeDir(temp_name);
+    errdefer parent_dir.deleteTree(temp_name) catch {};
+
+    var temp_dir = try parent_dir.openDir(temp_name, .{ .iterate = true, .access_sub_paths = true });
+    defer temp_dir.close();
+
+    const entry_count = extractArchive(temp_dir, options.archive_path, options.max_size) catch |err| switch (err) {
+        error.RestoreTooLarge,
+        error.UnsupportedRestoreEntry,
+        error.InvalidRestoreArchive,
+        error.OutOfMemory,
+        error.FileNotFound,
+        error.AccessDenied,
+        error.NoSpaceLeft,
+        error.FileTooBig,
+        error.NameTooLong,
+        error.PathAlreadyExists,
+        => return err,
+        else => if (isArchiveReadError(err)) return error.InvalidRestoreArchive else return err,
+    };
+    try validateRestoredStore(allocator, temp_dir);
+    const missing_count = try countMissingTracked(allocator, temp_dir);
+    try syncDir(temp_dir);
+
+    const rollback_name = if (options.replace_existing and try pathExists(parent_dir, store_name))
+        try makeUniqueSiblingName(allocator, parent_dir, store_name, rollback_suffix_prefix)
+    else
+        null;
+    errdefer if (rollback_name) |name| allocator.free(name);
+    const rollback_path = if (rollback_name) |name|
+        try std.fs.path.join(allocator, &.{ parent_path, name })
+    else
+        null;
+    errdefer if (rollback_path) |path| allocator.free(path);
+
+    if (rollback_name) |name| {
+        try parent_dir.rename(store_name, name);
+        errdefer parent_dir.rename(name, store_name) catch {};
+    } else if (try pathExists(parent_dir, store_name)) {
+        try parent_dir.deleteDir(store_name);
+    }
+
+    try parent_dir.rename(temp_name, store_name);
+    try syncDir(parent_dir);
+
+    if (rollback_name) |name| allocator.free(name);
+
+    return .{
+        .entry_count = entry_count,
+        .missing_tracked_count = missing_count,
+        .rollback_path = rollback_path,
+    };
+}
+
+// Rejects non-empty existing stores unless explicit replacement was requested.
+fn validateExistingStore(parent_dir: std.fs.Dir, store_name: []const u8, replace_existing: bool) !void {
+    var store_dir = parent_dir.openDir(store_name, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    defer store_dir.close();
+
+    if (!try isDirEmpty(store_dir) and !replace_existing) return error.RestoreTargetExists;
+}
+
+// Extracts one backup archive while validating its tar entry paths.
+fn extractArchive(
+    temp_dir: std.fs.Dir,
+    archive_path: []const u8,
+    max_size: u64,
+) !usize {
+    var archive = try std.fs.openFileAbsolute(archive_path, .{});
+    defer archive.close();
+
+    var file_buffer: [32 * 1024]u8 = undefined;
+    var file_reader = archive.reader(&file_buffer);
+    var inflate_buffer: [std.compress.flate.max_window_len]u8 = undefined;
+    var inflater: std.compress.flate.Decompress = .init(&file_reader.interface, .gzip, &inflate_buffer);
+
+    var file_name_buffer: [std.fs.max_path_bytes]u8 = undefined;
+    var link_name_buffer: [std.fs.max_path_bytes]u8 = undefined;
+    var tar_iter: std.tar.Iterator = .init(&inflater.reader, .{
+        .file_name_buffer = &file_name_buffer,
+        .link_name_buffer = &link_name_buffer,
+    });
+
+    var entry_count: usize = 0;
+    var extracted_bytes: u64 = 0;
+    while (try tar_iter.next()) |entry| {
+        const relative_path = try validateArchiveEntryPath(entry);
+        if (relative_path.len == 0) continue;
+
+        switch (entry.kind) {
+            .directory => try temp_dir.makePath(relative_path),
+            .file => {
+                extracted_bytes = try addSize(extracted_bytes, entry.size);
+                if (extracted_bytes > max_size) return error.RestoreTooLarge;
+                try writeExtractedFile(temp_dir, relative_path, &tar_iter, entry);
+            },
+            .sym_link => return error.UnsupportedRestoreEntry,
+        }
+        entry_count += 1;
+    }
+
+    return entry_count;
+}
+
+// Validates backup paths and returns the path relative to the store root.
+fn validateArchiveEntryPath(entry: std.tar.Iterator.File) ![]const u8 {
+    if (entry.name.len == 0) return error.InvalidRestoreArchive;
+    if (entry.name[0] == '/') return error.InvalidRestoreArchive;
+    if (std.mem.eql(u8, entry.name, backup_root)) {
+        if (entry.kind == .directory) return "";
+        return error.InvalidRestoreArchive;
+    }
+    if (!std.mem.startsWith(u8, entry.name, backup_root ++ "/")) return error.InvalidRestoreArchive;
+
+    const relative_path = entry.name[backup_root.len + 1 ..];
+    if (relative_path.len == 0) return error.InvalidRestoreArchive;
+    if (std.mem.indexOfScalar(u8, relative_path, '\\') != null) return error.InvalidRestoreArchive;
+    if (std.mem.eql(u8, relative_path, "LOCK")) return error.UnsupportedRestoreEntry;
+
+    var components = std.mem.splitScalar(u8, relative_path, '/');
+    while (components.next()) |component| {
+        if (component.len == 0) return error.InvalidRestoreArchive;
+        if (std.mem.eql(u8, component, ".") or std.mem.eql(u8, component, "..")) return error.InvalidRestoreArchive;
+        if (std.mem.eql(u8, component, ".trash")) return error.UnsupportedRestoreEntry;
+    }
+    return relative_path;
+}
+
+// Streams one tar file entry into the temporary store directory and fsyncs it.
+fn writeExtractedFile(
+    temp_dir: std.fs.Dir,
+    path: []const u8,
+    tar_iter: *std.tar.Iterator,
+    entry: std.tar.Iterator.File,
+) !void {
+    try ensureParentDirs(temp_dir, path);
+    var file = try temp_dir.createFile(path, .{ .exclusive = true });
+    errdefer file.close();
+
+    var out_buffer: [32 * 1024]u8 = undefined;
+    var writer = file.writer(&out_buffer);
+    try tar_iter.streamRemaining(entry, &writer.interface);
+    try writer.interface.flush();
+    try file.sync();
+    file.close();
+    try syncParentDir(temp_dir, path);
+}
+
+// Validates restored metadata through the existing version guard.
+fn validateRestoredStore(allocator: std.mem.Allocator, temp_dir: std.fs.Dir) !void {
+    try version_guard.ensureStoreVersion(allocator, temp_dir);
+}
+
+// Counts tracked records whose absolute paths do not exist in this environment.
+fn countMissingTracked(allocator: std.mem.Allocator, temp_dir: std.fs.Dir) !usize {
+    var tracked_dir = temp_dir.openDir("tracked", .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return 0,
+        else => return err,
+    };
+    defer tracked_dir.close();
+
+    var missing: usize = 0;
+    var it = tracked_dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .file) continue;
+        _ = constrained_types.TrackedFileId.init(entry.name) catch return error.InvalidRestoreArchive;
+
+        const bytes = try tracked_dir.readFileAlloc(allocator, entry.name, max_tracked_file_size);
+        defer allocator.free(bytes);
+        const path = std.mem.trim(u8, std.mem.trimRight(u8, bytes, "\r\n"), " \t");
+        _ = constrained_types.TrackedFilePath.init(path) catch return error.InvalidRestoreArchive;
+
+        var target = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+            error.FileNotFound => {
+                missing += 1;
+                continue;
+            },
+            else => return err,
+        };
+        target.close();
+    }
+    return missing;
+}
+
+// Reports whether the opened directory has no entries.
+fn isDirEmpty(dir: std.fs.Dir) !bool {
+    var it = dir.iterate();
+    while (try it.next()) |_| return false;
+    return true;
+}
+
+// Reports whether a path exists below the parent directory.
+fn pathExists(parent_dir: std.fs.Dir, name: []const u8) !bool {
+    parent_dir.access(name, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    return true;
+}
+
+// Builds a unique sibling directory name for temp and rollback directories.
+fn makeUniqueSiblingName(
+    allocator: std.mem.Allocator,
+    parent_dir: std.fs.Dir,
+    store_name: []const u8,
+    suffix_prefix: []const u8,
+) ![]u8 {
+    var attempts: usize = 0;
+    while (attempts < 32) : (attempts += 1) {
+        var random: [8]u8 = undefined;
+        std.crypto.random.bytes(&random);
+        var hex: [random.len * 2]u8 = undefined;
+        encodeHexLower(&hex, &random);
+        const name = try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ store_name, suffix_prefix, &hex });
+        if (!try pathExists(parent_dir, name)) return name;
+        allocator.free(name);
+    }
+    return error.PathAlreadyExists;
+}
+
+// Adds file sizes with overflow protection.
+fn addSize(lhs: u64, rhs: u64) !u64 {
+    return std.math.add(u64, lhs, rhs) catch return error.RestoreTooLarge;
+}
+
+// Reports gzip/tar reader failures that mean the archive is not a valid backup.
+fn isArchiveReadError(err: anyerror) bool {
+    const name = @errorName(err);
+    if (std.mem.startsWith(u8, name, "Tar")) return true;
+    return err == error.BadMagic or
+        err == error.EndOfStream or
+        err == error.ReadFailed or
+        err == error.InvalidStoredSize or
+        err == error.InvalidBlockType or
+        err == error.InvalidDynamicBlockHeader or
+        err == error.WrongChecksum;
+}
+
+// Ensures that the parent directories for a relative path exist.
+fn ensureParentDirs(dir: std.fs.Dir, path: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        if (parent.len == 0) return;
+        try dir.makePath(parent);
+    }
+}
+
+// Fsyncs the parent directory for one relative path.
+fn syncParentDir(dir: std.fs.Dir, path: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        if (parent.len == 0) {
+            try syncDir(dir);
+            return;
+        }
+        var parent_dir = try dir.openDir(parent, .{});
+        defer parent_dir.close();
+        try syncDir(parent_dir);
+    } else {
+        try syncDir(dir);
+    }
+}
+
+// Fsyncs a directory and tolerates platforms that reject directory fsync.
+fn syncDir(dir: std.fs.Dir) !void {
+    const rc = std.posix.system.fsync(dir.fd);
+    switch (std.posix.errno(rc)) {
+        .SUCCESS, .BADF, .INVAL, .ROFS => return,
+        else => |err| return std.posix.unexpectedErrno(err),
+    }
+}
+
+// Encodes bytes into lowercase hexadecimal characters.
+fn encodeHexLower(dest: []u8, source: []const u8) void {
+    const alphabet = "0123456789abcdef";
+    var idx: usize = 0;
+    for (source) |byte| {
+        dest[idx] = alphabet[@as(usize, byte >> 4)];
+        dest[idx + 1] = alphabet[@as(usize, byte & 0x0f)];
+        idx += 2;
+    }
+}
+
+test "restoreBackup restores archive created by backup writer" {
+    const backup = @import("./backup.zig");
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var source_dir = try tmp.dir.makeOpenPath("source/.omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer source_dir.close();
+
+    try source_dir.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+    try source_dir.makePath("tracked");
+    const root_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root_path);
+    const tracked_path = try std.fmt.allocPrint(allocator, "{s}/missing-target.txt", .{root_path});
+    defer allocator.free(tracked_path);
+    try source_dir.writeFile(.{
+        .sub_path = "tracked/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        .data = tracked_path,
+    });
+    try source_dir.makePath("objects/aa");
+    try source_dir.writeFile(.{
+        .sub_path = "objects/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        .data = "content\n",
+    });
+
+    const source_store_path = try tmp.dir.realpathAlloc(allocator, "source/.omohi");
+    defer allocator.free(source_store_path);
+    const archive_parent = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(archive_parent);
+    const archive_path = try std.fs.path.join(allocator, &.{ archive_parent, "backup.tar.gz" });
+    defer allocator.free(archive_path);
+
+    _ = try backup.writeBackup(allocator, source_dir, .{
+        .store_path = source_store_path,
+        .archive_path = archive_path,
+        .max_size = 1024 * 1024,
+    });
+
+    try tmp.dir.makePath("dest");
+    const dest_store_path = try std.fs.path.join(allocator, &.{ archive_parent, "dest", ".omohi" });
+    defer allocator.free(dest_store_path);
+
+    var result = try restoreBackup(allocator, .{
+        .store_path = dest_store_path,
+        .archive_path = archive_path,
+        .replace_existing = false,
+        .max_size = 1024 * 1024,
+    });
+    defer freeRestoreResult(allocator, &result);
+
+    try std.testing.expect(result.entry_count > 0);
+    try std.testing.expectEqual(@as(usize, 1), result.missing_tracked_count);
+    try std.testing.expectEqual(@as(?[]u8, null), result.rollback_path);
+
+    var restored = try std.fs.openDirAbsolute(dest_store_path, .{ .iterate = true, .access_sub_paths = true });
+    defer restored.close();
+    const version = try restored.readFileAlloc(allocator, "VERSION", 16);
+    defer allocator.free(version);
+    try std.testing.expectEqualStrings("1\n", version);
+
+    const tracked = try restored.readFileAlloc(allocator, "tracked/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 512);
+    defer allocator.free(tracked);
+    try std.testing.expectEqualStrings(tracked_path, tracked);
+}
+
+test "restoreBackup rejects non-empty target without replace" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    const root_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ root_path, "missing.tar.gz" });
+    defer allocator.free(archive_path);
+
+    var existing = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer existing.close();
+    try existing.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+
+    const store_path = try tmp.dir.realpathAlloc(allocator, ".omohi");
+    defer allocator.free(store_path);
+
+    try std.testing.expectError(error.RestoreTargetExists, restoreBackup(allocator, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .replace_existing = false,
+        .max_size = 1024,
+    }));
+}
+
+test "restoreBackup rejects oversized and invalid archives" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    const root_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ root_path, "invalid.tar.gz" });
+    defer allocator.free(archive_path);
+    try tmp.dir.writeFile(.{ .sub_path = "invalid.tar.gz", .data = "not gzip" });
+    try tmp.dir.makePath("dest");
+    const store_path = try std.fs.path.join(allocator, &.{ root_path, "dest", ".omohi" });
+    defer allocator.free(store_path);
+
+    try std.testing.expectError(error.RestoreTooLarge, restoreBackup(allocator, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .replace_existing = false,
+        .max_size = 1,
+    }));
+    try std.testing.expectError(error.InvalidRestoreArchive, restoreBackup(allocator, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .replace_existing = false,
+        .max_size = 1024,
+    }));
+}
+
+test "restoreBackup replaces non-empty target and leaves rollback directory" {
+    const backup = @import("./backup.zig");
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const allocator = std.testing.allocator;
+    var source_dir = try tmp.dir.makeOpenPath("source/.omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer source_dir.close();
+    try source_dir.writeFile(.{ .sub_path = "VERSION", .data = "1\n" });
+    try source_dir.makePath("tracked");
+
+    const root_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root_path);
+    const source_store_path = try tmp.dir.realpathAlloc(allocator, "source/.omohi");
+    defer allocator.free(source_store_path);
+    const archive_path = try std.fs.path.join(allocator, &.{ root_path, "backup.tar.gz" });
+    defer allocator.free(archive_path);
+    _ = try backup.writeBackup(allocator, source_dir, .{
+        .store_path = source_store_path,
+        .archive_path = archive_path,
+        .max_size = 1024 * 1024,
+    });
+
+    var existing = try tmp.dir.makeOpenPath(".omohi", .{ .iterate = true, .access_sub_paths = true });
+    defer existing.close();
+    try existing.writeFile(.{ .sub_path = "VERSION", .data = "old\n" });
+
+    const store_path = try tmp.dir.realpathAlloc(allocator, ".omohi");
+    defer allocator.free(store_path);
+
+    var result = try restoreBackup(allocator, .{
+        .store_path = store_path,
+        .archive_path = archive_path,
+        .replace_existing = true,
+        .max_size = 1024 * 1024,
+    });
+    defer freeRestoreResult(allocator, &result);
+
+    try std.testing.expect(result.rollback_path != null);
+    var rollback = try std.fs.openDirAbsolute(result.rollback_path.?, .{});
+    defer rollback.close();
+    const old_version = try rollback.readFileAlloc(allocator, "VERSION", 16);
+    defer allocator.free(old_version);
+    try std.testing.expectEqualStrings("old\n", old_version);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -23,6 +23,7 @@ const _store_local_trash = @import("store/local/trash.zig");
 const _store_local_version = @import("store/local/version.zig");
 const _store_local_journal = @import("store/local/journal.zig");
 const _store_local_backup = @import("store/local/backup.zig");
+const _store_local_restore = @import("store/local/restore.zig");
 // testing
 const _testing_persistence_fixture_inspector = @import("testing/persistence_fixture_inspector.zig");
 const _testing_store_api_test_support = @import("testing/store_api_test_support.zig");
@@ -40,6 +41,7 @@ const _ops_completion = @import("ops/completion_ops.zig");
 const _ops_journal_append = @import("ops/journal/append.zig");
 const _ops_journal = @import("ops/journal_ops.zig");
 const _ops_backup = @import("ops/backup_ops.zig");
+const _ops_restore = @import("ops/restore_ops.zig");
 
 // app/cli tests
 const _app_cli_run = @import("app/cli/run.zig");
@@ -55,6 +57,7 @@ const _app_cli_output = @import("app/cli/presenter/output.zig");
 const _app_cli_version = @import("app/cli/command/version.zig");
 const _app_cli_journal = @import("app/cli/command/journal.zig");
 const _app_cli_backup = @import("app/cli/command/backup.zig");
+const _app_cli_restore = @import("app/cli/command/restore.zig");
 const _app_cli_command_catalog = @import("app/cli/command_catalog.zig");
 const _app_cli_docs_render_markdown = @import("app/cli/docs/render_markdown.zig");
 const _app_cli_docs_render_man = @import("app/cli/docs/render_man.zig");
@@ -81,6 +84,7 @@ test "load modules" {
     _ = _store_local_version;
     _ = _store_local_journal;
     _ = _store_local_backup;
+    _ = _store_local_restore;
     _ = _testing_persistence_fixture_inspector;
     _ = _testing_store_api_test_support;
     _ = _ops_track;
@@ -95,6 +99,7 @@ test "load modules" {
     _ = _ops_journal_append;
     _ = _ops_journal;
     _ = _ops_backup;
+    _ = _ops_restore;
     _ = _app_cli_run;
     _ = _app_cli_error_map;
     _ = _app_cli_error_message;
@@ -108,6 +113,7 @@ test "load modules" {
     _ = _app_cli_version;
     _ = _app_cli_journal;
     _ = _app_cli_backup;
+    _ = _app_cli_restore;
     _ = _app_cli_command_catalog;
     _ = _app_cli_docs_render_markdown;
     _ = _app_cli_docs_render_man;


### PR DESCRIPTION
## Summary
- Add store-level restore support for full `omohi backup` tar.gz archives.
- Wire `omohi restore [--replace] [--max-size <bytes>] <archivePath>` through ops and CLI layers.
- Update command docs, shell completion, and e2e coverage for restore flows.

## Behavior
- Restore rejects an existing non-empty `~/.omohi` unless `--replace` is specified.
- `--replace` moves the previous store to a rollback directory beside `~/.omohi` before installing the restored store.
- Stored absolute paths are restored unchanged; paths from another environment may show as missing in `omohi status`.

## Validation
- `make test`
- `make fmt-check`
- `make test-completion`
- `make test-contract`
- `make test-smoke`
- `make test-e2e-matrix`